### PR TITLE
Add Akashic play launch flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,20 @@
 #FIREBASE_MESSAGING_SENDER_ID: "166175468898",
 #FIREBASE_APP_ID: "1:166175468898:web:4c8f59dc4638de3f1dd03b",
 #FIREBASE_MEASUREMENT_ID: "G-TBNNR7GQ2R",
+
+# Scramble functions -> Akashic System
+#AKASHIC_SYSTEM_API_BASE_URL="https://akashic-system.shinonomekazan.com/api"
+#AKASHIC_SYSTEM_API_KEY=""
+#AKASHIC_SYSTEM_GAME_PAGE_URL="https://akashic-system.shinonomekazan.com/contents/index.html"
+#SCRAMBLE_AKASHIC_GAME_CODE="rocket-game"
+#SCRAMBLE_AKASHIC_GAME_TITLE="Rocket Game"
+#SCRAMBLE_AKASHIC_GAME_DESCRIPTION=""
+#SCRAMBLE_AKASHIC_CONTENT_URL="/contents/rocket-game/content.json"
+#SCRAMBLE_AKASHIC_INPUT_ADAPTER="rocket-game"
+
+# Optional: Scramble functions -> Akashic Game Drive
+# If SCRAMBLE_GAME_DRIVE_CONTENT_ID is set, Scramble resolves content.json from Game Drive instead of SCRAMBLE_AKASHIC_CONTENT_URL.
+#GAME_DRIVE_API_BASE_URL="https://asia-northeast1-akashic-game-drive.cloudfunctions.net/api"
+#GAME_DRIVE_API_KEY=""
+#GAME_DRIVE_CONTENT_CDN_BASE_URL="https://drive.akashic.shinonomekazan.com"
+#SCRAMBLE_GAME_DRIVE_CONTENT_ID=""

--- a/.env.example
+++ b/.env.example
@@ -5,20 +5,3 @@
 #FIREBASE_MESSAGING_SENDER_ID: "166175468898",
 #FIREBASE_APP_ID: "1:166175468898:web:4c8f59dc4638de3f1dd03b",
 #FIREBASE_MEASUREMENT_ID: "G-TBNNR7GQ2R",
-
-# Scramble functions -> Akashic System
-#AKASHIC_SYSTEM_API_BASE_URL="https://akashic-system.shinonomekazan.com/api"
-#AKASHIC_SYSTEM_API_KEY=""
-#AKASHIC_SYSTEM_GAME_PAGE_URL="https://akashic-system.shinonomekazan.com/contents/index.html"
-#SCRAMBLE_AKASHIC_GAME_CODE="rocket-game"
-#SCRAMBLE_AKASHIC_GAME_TITLE="Rocket Game"
-#SCRAMBLE_AKASHIC_GAME_DESCRIPTION=""
-#SCRAMBLE_AKASHIC_CONTENT_URL="/contents/rocket-game/content.json"
-#SCRAMBLE_AKASHIC_INPUT_ADAPTER="rocket-game"
-
-# Optional: Scramble functions -> Akashic Game Drive
-# If SCRAMBLE_GAME_DRIVE_CONTENT_ID is set, Scramble resolves content.json from Game Drive instead of SCRAMBLE_AKASHIC_CONTENT_URL.
-#GAME_DRIVE_API_BASE_URL="https://asia-northeast1-akashic-game-drive.cloudfunctions.net/api"
-#GAME_DRIVE_API_KEY=""
-#GAME_DRIVE_CONTENT_CDN_BASE_URL="https://drive.akashic.shinonomekazan.com"
-#SCRAMBLE_GAME_DRIVE_CONTENT_ID=""

--- a/.github/workflows/firebase-functions.yml
+++ b/.github/workflows/firebase-functions.yml
@@ -25,13 +25,13 @@ jobs:
         run: cp ./functions/.env.production ./functions/.env
       - name: Add production function secrets
         env:
-          PRODUCTION_AKASHIC_SYSTEM_API_KEY: ${{ secrets.PRODUCTION_AKASHIC_SYSTEM_API_KEY }}
+          AKASHIC_SYSTEM_API_KEY: ${{ secrets.AKASHIC_SYSTEM_API_KEY }}
         run: |
-          if [ -z "$PRODUCTION_AKASHIC_SYSTEM_API_KEY" ]; then
-            echo "PRODUCTION_AKASHIC_SYSTEM_API_KEY is not configured." >&2
+          if [ -z "$AKASHIC_SYSTEM_API_KEY" ]; then
+            echo "AKASHIC_SYSTEM_API_KEY is not configured." >&2
             exit 1
           fi
-          printf 'AKASHIC_SYSTEM_API_KEY=%s\n' "$PRODUCTION_AKASHIC_SYSTEM_API_KEY" >> ./functions/.env
+          printf 'AKASHIC_SYSTEM_API_KEY=%s\n' "$AKASHIC_SYSTEM_API_KEY" >> ./functions/.env
       - name: npm ci
         run: npm ci && npm --prefix ./functions ci
       - name: Deploy functions

--- a/.github/workflows/firebase-functions.yml
+++ b/.github/workflows/firebase-functions.yml
@@ -23,6 +23,15 @@ jobs:
             functions/package-lock.json
       - name: デプロイ用.envひな型の作成
         run: cp ./functions/.env.production ./functions/.env
+      - name: Add production function secrets
+        env:
+          PRODUCTION_AKASHIC_SYSTEM_API_KEY: ${{ secrets.PRODUCTION_AKASHIC_SYSTEM_API_KEY }}
+        run: |
+          if [ -z "$PRODUCTION_AKASHIC_SYSTEM_API_KEY" ]; then
+            echo "PRODUCTION_AKASHIC_SYSTEM_API_KEY is not configured." >&2
+            exit 1
+          fi
+          printf 'AKASHIC_SYSTEM_API_KEY=%s\n' "$PRODUCTION_AKASHIC_SYSTEM_API_KEY" >> ./functions/.env
       - name: npm ci
         run: npm ci && npm --prefix ./functions ci
       - name: Deploy functions

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -1,0 +1,16 @@
+# Scramble functions -> Akashic System
+AKASHIC_SYSTEM_API_BASE_URL="https://akashic-system.shinonomekazan.com/api"
+AKASHIC_SYSTEM_API_KEY=""
+AKASHIC_SYSTEM_GAME_PAGE_URL="https://akashic-system.shinonomekazan.com/contents/index.html"
+SCRAMBLE_AKASHIC_GAME_CODE="rocket-game"
+SCRAMBLE_AKASHIC_GAME_TITLE="Rocket Game"
+SCRAMBLE_AKASHIC_GAME_DESCRIPTION=""
+SCRAMBLE_AKASHIC_CONTENT_URL="/contents/rocket-game/content.json"
+SCRAMBLE_AKASHIC_INPUT_ADAPTER="rocket-game"
+
+# Optional: Scramble functions -> Akashic Game Drive
+# If SCRAMBLE_GAME_DRIVE_CONTENT_ID is set, Scramble resolves content.json from Game Drive instead of SCRAMBLE_AKASHIC_CONTENT_URL.
+GAME_DRIVE_API_BASE_URL="https://asia-northeast1-akashic-game-drive.cloudfunctions.net/api"
+GAME_DRIVE_API_KEY=""
+GAME_DRIVE_CONTENT_CDN_BASE_URL="https://drive.akashic.shinonomekazan.com"
+SCRAMBLE_GAME_DRIVE_CONTENT_ID=""

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -2,15 +2,8 @@
 AKASHIC_SYSTEM_API_BASE_URL="https://akashic-system.shinonomekazan.com/api"
 AKASHIC_SYSTEM_API_KEY=""
 AKASHIC_SYSTEM_GAME_PAGE_URL="https://akashic-system.shinonomekazan.com/contents/index.html"
-SCRAMBLE_AKASHIC_GAME_CODE="rocket-game"
-SCRAMBLE_AKASHIC_GAME_TITLE="Rocket Game"
-SCRAMBLE_AKASHIC_GAME_DESCRIPTION=""
-SCRAMBLE_AKASHIC_CONTENT_URL="/contents/rocket-game/content.json"
-SCRAMBLE_AKASHIC_INPUT_ADAPTER="rocket-game"
 
 # Optional: Scramble functions -> Akashic Game Drive
-# If SCRAMBLE_GAME_DRIVE_CONTENT_ID is set, Scramble resolves content.json from Game Drive instead of SCRAMBLE_AKASHIC_CONTENT_URL.
 GAME_DRIVE_API_BASE_URL="https://asia-northeast1-akashic-game-drive.cloudfunctions.net/api"
 GAME_DRIVE_API_KEY=""
 GAME_DRIVE_CONTENT_CDN_BASE_URL="https://drive.akashic.shinonomekazan.com"
-SCRAMBLE_GAME_DRIVE_CONTENT_ID=""

--- a/functions/src/App.ts
+++ b/functions/src/App.ts
@@ -19,10 +19,4 @@ export class App extends fw.App<AppConfig> {
 		this.auth = getAuth(firebaseApp);
 	}
 
-	enableCredentials() {
-		this.app.use((req, res, next) => {
-			res.header("Access-Control-Allow-Credentials", "true");
-			next();
-		});
-	}
 }

--- a/functions/src/controllers/HoldPlacesController.ts
+++ b/functions/src/controllers/HoldPlacesController.ts
@@ -48,7 +48,7 @@ export class HoldPlacesController extends BaseController {
 			holdPlaceId: p.id,
 		});
 		const config = loadAkashicSystemConfig();
-		const mode: AkashicExecutionMode = playInfo.activeUserId === verifyResult.uid ? "active" : "passive";
+		const mode: AkashicExecutionMode = playInfo.ownerUserId === verifyResult.uid ? "active" : "passive";
 		const userId = `scramble-${verifyResult.uid}`;
 		const token = await new AkashicSystemClient(config).createToken(playInfo.currentPlayId!, userId, mode);
 
@@ -58,11 +58,11 @@ export class HoldPlacesController extends BaseController {
 			playId: playInfo.currentPlayId,
 			mode,
 			userId,
-			gameCode: playInfo.currentPlayGameCode ?? config.defaultGameCode,
-			gameTitle: playInfo.currentPlayTitle ?? config.defaultGameTitle,
-			gameDescription: playInfo.currentPlayDescription ?? config.defaultGameDescription,
-			contentUrl: playInfo.currentPlayContentUrl ?? config.defaultContentUrl,
-			inputAdapter: playInfo.currentPlayInputAdapter ?? config.defaultInputAdapter,
+			gameCode: playInfo.gameCode ?? config.defaultGameCode,
+			gameTitle: playInfo.gameTitle ?? config.defaultGameTitle,
+			gameDescription: playInfo.gameDescription ?? config.defaultGameDescription,
+			contentUrl: playInfo.contentUrl ?? config.defaultContentUrl,
+			inputAdapter: playInfo.inputAdapter ?? config.defaultInputAdapter,
 			expireAt: playInfo.expireAt?.toDate().toISOString(),
 			playToken: token.value,
 			playlogServerUrl: token.url,
@@ -79,7 +79,7 @@ export class HoldPlacesController extends BaseController {
 			requireOwner: true,
 		});
 		if (playInfo.currentPlayId) {
-			await new AkashicSystemClient().stopPlay(playInfo.currentPlayId);
+			await this.stopAkashicPlayIfConfigured(playInfo.currentPlayId);
 		}
 		return {
 			result: "ok",
@@ -87,5 +87,14 @@ export class HoldPlacesController extends BaseController {
 			placeId: playInfo.placeId,
 			playId: playInfo.currentPlayId,
 		};
+	}
+
+	private async stopAkashicPlayIfConfigured(playId: string) {
+		if (!process.env.AKASHIC_SYSTEM_API_KEY) return;
+		try {
+			await new AkashicSystemClient().stopPlay(playId);
+		} catch (error) {
+			console.warn(error);
+		}
 	}
 }

--- a/functions/src/controllers/HoldPlacesController.ts
+++ b/functions/src/controllers/HoldPlacesController.ts
@@ -6,6 +6,7 @@ import * as params from "../params";
 import { Router } from "express";
 import { clearHoldPlacePlay, getHoldPlacePlayInfo } from "../stores";
 import { AkashicExecutionMode, AkashicSystemClient, loadAkashicSystemConfig } from "../services/akashicSystem";
+import { buildAkashicGameCode, resolvePlayContentInfo } from "../services/playContent";
 
 interface IdParams {
 	authorization: string;
@@ -51,6 +52,7 @@ export class HoldPlacesController extends BaseController {
 		const mode: AkashicExecutionMode = playInfo.ownerUserId === verifyResult.uid ? "active" : "passive";
 		const userId = `scramble-${verifyResult.uid}`;
 		const token = await new AkashicSystemClient(config).createToken(playInfo.currentPlayId!, userId, mode);
+		const content = await resolvePlayContentInfo(playInfo);
 
 		return {
 			holdPlaceId: playInfo.holdPlaceId,
@@ -58,11 +60,11 @@ export class HoldPlacesController extends BaseController {
 			playId: playInfo.currentPlayId,
 			mode,
 			userId,
-			gameCode: playInfo.gameCode ?? config.defaultGameCode,
-			gameTitle: playInfo.gameTitle ?? config.defaultGameTitle,
-			gameDescription: playInfo.gameDescription ?? config.defaultGameDescription,
-			contentUrl: playInfo.contentUrl ?? config.defaultContentUrl,
-			inputAdapter: playInfo.inputAdapter ?? config.defaultInputAdapter,
+			gameCode: buildAkashicGameCode(playInfo.holdPlaceId, content.contentCode),
+			gameTitle: content.title,
+			gameDescription: content.description,
+			contentUrl: content.contentUrl,
+			inputAdapter: content.inputAdapter,
 			expireAt: playInfo.expireAt?.toDate().toISOString(),
 			playToken: token.value,
 			playlogServerUrl: token.url,

--- a/functions/src/controllers/HoldPlacesController.ts
+++ b/functions/src/controllers/HoldPlacesController.ts
@@ -4,7 +4,8 @@ import * as validators from "express-validator";
 import * as fw from "../fw";
 import * as params from "../params";
 import { Router } from "express";
-import { clearHoldPlacePlay, getHoldPlacePlayInfo } from "../stores";
+import { clearHoldPlacePlay } from "../stores";
+import { getHoldPlacePlayInfo } from "../resolvers/holdPlaces";
 import { AkashicExecutionMode, AkashicSystemClient, loadAkashicSystemConfig } from "../services/akashicSystem";
 import { resolvePlayContentInfo } from "../services/playContent";
 

--- a/functions/src/controllers/HoldPlacesController.ts
+++ b/functions/src/controllers/HoldPlacesController.ts
@@ -6,7 +6,7 @@ import * as params from "../params";
 import { Router } from "express";
 import { clearHoldPlacePlay, getHoldPlacePlayInfo } from "../stores";
 import { AkashicExecutionMode, AkashicSystemClient, loadAkashicSystemConfig } from "../services/akashicSystem";
-import { buildAkashicGameCode, resolvePlayContentInfo } from "../services/playContent";
+import { resolvePlayContentInfo } from "../services/playContent";
 
 interface IdParams {
 	authorization: string;
@@ -60,11 +60,9 @@ export class HoldPlacesController extends BaseController {
 			playId: playInfo.currentPlayId,
 			mode,
 			userId,
-			gameCode: buildAkashicGameCode(playInfo.holdPlaceId, content.contentCode),
 			gameTitle: content.title,
 			gameDescription: content.description,
 			contentUrl: content.contentUrl,
-			inputAdapter: content.inputAdapter,
 			expireAt: playInfo.expireAt?.toDate().toISOString(),
 			playToken: token.value,
 			playlogServerUrl: token.url,

--- a/functions/src/controllers/HoldPlacesController.ts
+++ b/functions/src/controllers/HoldPlacesController.ts
@@ -20,7 +20,14 @@ export class HoldPlacesController extends BaseController {
 
 		this.registerRoute(router, "POST", "/:id/play/launch", this.launchPlay, [
 			fw.params.InstantValidator(
-				[params.headerBearerTokenValidator(), validators.param("id").isString().notEmpty()],
+				[
+					params.headerBearerTokenValidator(),
+					validators
+						.param("id")
+						.isString()
+						.notEmpty()
+						.matches(/^[^/]+$/),
+				],
 				(context) =>
 					({
 						authorization: context.req.headers.authorization,
@@ -31,7 +38,14 @@ export class HoldPlacesController extends BaseController {
 
 		this.registerRoute(router, "POST", "/:id/play/end", this.endPlay, [
 			fw.params.InstantValidator(
-				[params.headerBearerTokenValidator(), validators.param("id").isString().notEmpty()],
+				[
+					params.headerBearerTokenValidator(),
+					validators
+						.param("id")
+						.isString()
+						.notEmpty()
+						.matches(/^[^/]+$/),
+				],
 				(context) =>
 					({
 						authorization: context.req.headers.authorization,

--- a/functions/src/controllers/HoldPlacesController.ts
+++ b/functions/src/controllers/HoldPlacesController.ts
@@ -1,0 +1,91 @@
+import { Context } from "../Context";
+import BaseController from "./BaseController";
+import * as validators from "express-validator";
+import * as fw from "../fw";
+import * as params from "../params";
+import { Router } from "express";
+import { clearHoldPlacePlay, getHoldPlacePlayInfo } from "../stores";
+import { AkashicExecutionMode, AkashicSystemClient, loadAkashicSystemConfig } from "../services/akashicSystem";
+
+interface IdParams {
+	authorization: string;
+	id: string;
+}
+
+export class HoldPlacesController extends BaseController {
+	register(basePath: string): Router {
+		const router = super.register(basePath);
+
+		this.registerRoute(router, "POST", "/:id/play/launch", this.launchPlay, [
+			fw.params.InstantValidator(
+				[params.headerBearerTokenValidator(), validators.param("id").isString().notEmpty()],
+				(context) =>
+					({
+						authorization: context.req.headers.authorization,
+						id: context.req.params.id as string,
+					}) as IdParams,
+			),
+		]);
+
+		this.registerRoute(router, "POST", "/:id/play/end", this.endPlay, [
+			fw.params.InstantValidator(
+				[params.headerBearerTokenValidator(), validators.param("id").isString().notEmpty()],
+				(context) =>
+					({
+						authorization: context.req.headers.authorization,
+						id: context.req.params.id as string,
+					}) as IdParams,
+			),
+		]);
+
+		return router;
+	}
+
+	async launchPlay(context: Context) {
+		const p = context.params as IdParams;
+		const verifyResult = await this.verify(p.authorization);
+		const playInfo = await getHoldPlacePlayInfo(this.app.firestore, {
+			holdPlaceId: p.id,
+		});
+		const config = loadAkashicSystemConfig();
+		const mode: AkashicExecutionMode = playInfo.activeUserId === verifyResult.uid ? "active" : "passive";
+		const userId = `scramble-${verifyResult.uid}`;
+		const token = await new AkashicSystemClient(config).createToken(playInfo.currentPlayId!, userId, mode);
+
+		return {
+			holdPlaceId: playInfo.holdPlaceId,
+			placeId: playInfo.placeId,
+			playId: playInfo.currentPlayId,
+			mode,
+			userId,
+			gameCode: playInfo.currentPlayGameCode ?? config.defaultGameCode,
+			gameTitle: playInfo.currentPlayTitle ?? config.defaultGameTitle,
+			gameDescription: playInfo.currentPlayDescription ?? config.defaultGameDescription,
+			contentUrl: playInfo.currentPlayContentUrl ?? config.defaultContentUrl,
+			inputAdapter: playInfo.currentPlayInputAdapter ?? config.defaultInputAdapter,
+			expireAt: playInfo.expireAt?.toDate().toISOString(),
+			playToken: token.value,
+			playlogServerUrl: token.url,
+			gamePageUrl: config.gamePageUrl,
+		};
+	}
+
+	async endPlay(context: Context) {
+		const p = context.params as IdParams;
+		const verifyResult = await this.verify(p.authorization);
+		const playInfo = await clearHoldPlacePlay(this.app.firestore, {
+			holdPlaceId: p.id,
+			holdUserId: verifyResult.uid,
+			requireOwner: true,
+		});
+		if (playInfo.currentPlayId) {
+			await new AkashicSystemClient().stopPlay(playInfo.currentPlayId);
+		}
+		return {
+			result: "ok",
+			holdPlaceId: playInfo.holdPlaceId,
+			placeId: playInfo.placeId,
+			playId: playInfo.currentPlayId,
+		};
+	}
+}

--- a/functions/src/controllers/PlacesController.ts
+++ b/functions/src/controllers/PlacesController.ts
@@ -6,7 +6,7 @@ import * as params from "../params";
 import { Router } from "express";
 import { getCurrentHoldPlacePlayInfo, holdPlace, releaseHoldPlace, setHoldPlacePlay } from "../stores";
 import { AkashicSystemClient, loadAkashicSystemConfig } from "../services/akashicSystem";
-import { GameDriveClient, loadGameDriveConfig } from "../services/gameDrive";
+import { buildAkashicGameCode, DEFAULT_SCRAMBLE_PLAY_CONTENT, resolvePlayContentInfo } from "../services/playContent";
 
 interface IdParams {
 	authorization: string;
@@ -85,23 +85,24 @@ export class PlacesController extends BaseController {
 			requireOwner: true,
 		});
 		if (target.currentPlayId) {
+			const content = await resolvePlayContentInfo(target);
 			return {
 				holdPlaceId: target.holdPlaceId,
 				placeId: target.placeId,
 				playId: target.currentPlayId,
-				gameCode: target.gameCode ?? config.defaultGameCode,
-				gameTitle: target.gameTitle ?? config.defaultGameTitle,
-				gameDescription: target.gameDescription ?? config.defaultGameDescription,
-				contentUrl: target.contentUrl ?? config.defaultContentUrl,
-				inputAdapter: target.inputAdapter ?? config.defaultInputAdapter,
+				gameCode: buildAkashicGameCode(target.holdPlaceId, content.contentCode),
+				gameTitle: content.title,
+				gameDescription: content.description,
+				contentUrl: content.contentUrl,
+				inputAdapter: content.inputAdapter,
 				expireAt: target.expireAt?.toDate().toISOString(),
 				joinPath: `/play/${encodeURIComponent(target.holdPlaceId)}`,
 			};
 		}
 
-		const game = await this.resolveGameConfig(config);
+		const content = DEFAULT_SCRAMBLE_PLAY_CONTENT;
 		const system = new AkashicSystemClient(config);
-		const gameCode = `scramble-${target.holdPlaceId}-${game.gameCode}`;
+		const gameCode = buildAkashicGameCode(target.holdPlaceId, content.contentCode);
 		const createdPlay = await system.createPlay(gameCode);
 		let storedPlay;
 		try {
@@ -109,13 +110,9 @@ export class PlacesController extends BaseController {
 				holdPlaceId: target.holdPlaceId,
 				holdUserId: verifyResult.uid,
 				systemPlayId: createdPlay.id,
-				providerId: game.providerId,
-				contentCode: game.contentCode,
-				gameCode,
-				gameTitle: game.title,
-				gameDescription: game.description,
-				contentUrl: game.contentUrl,
-				inputAdapter: config.defaultInputAdapter,
+				providerId: content.providerId,
+				contentCode: content.contentCode,
+				contentUrl: content.contentUrl,
 				ownerUserId: verifyResult.uid,
 			});
 
@@ -127,15 +124,16 @@ export class PlacesController extends BaseController {
 			throw error;
 		}
 
+		const storedContent = await resolvePlayContentInfo(storedPlay);
 		return {
 			holdPlaceId: storedPlay.holdPlaceId,
 			placeId: storedPlay.placeId,
 			playId: storedPlay.currentPlayId,
-			gameCode: storedPlay.gameCode ?? gameCode,
-			gameTitle: storedPlay.gameTitle ?? config.defaultGameTitle,
-			gameDescription: storedPlay.gameDescription ?? config.defaultGameDescription,
-			contentUrl: storedPlay.contentUrl ?? config.defaultContentUrl,
-			inputAdapter: storedPlay.inputAdapter ?? config.defaultInputAdapter,
+			gameCode: buildAkashicGameCode(storedPlay.holdPlaceId, storedContent.contentCode),
+			gameTitle: storedContent.title,
+			gameDescription: storedContent.description,
+			contentUrl: storedContent.contentUrl,
+			inputAdapter: storedContent.inputAdapter,
 			expireAt: storedPlay.expireAt?.toDate().toISOString(),
 			joinPath: `/play/${encodeURIComponent(storedPlay.holdPlaceId)}`,
 		};
@@ -148,29 +146,5 @@ export class PlacesController extends BaseController {
 		} catch (error) {
 			console.warn(error);
 		}
-	}
-
-	private async resolveGameConfig(config: ReturnType<typeof loadAkashicSystemConfig>) {
-		const gameDriveConfig = loadGameDriveConfig();
-		if (!gameDriveConfig.contentId) {
-			return {
-				providerId: "akashic-system",
-				contentCode: config.defaultGameCode,
-				gameCode: config.defaultGameCode,
-				title: config.defaultGameTitle,
-				description: config.defaultGameDescription,
-				contentUrl: config.defaultContentUrl,
-			};
-		}
-
-		const content = await new GameDriveClient(gameDriveConfig).resolveContent(gameDriveConfig.contentId);
-		return {
-			providerId: "akashic-game-drive",
-			contentCode: content.contentId,
-			gameCode: `game-drive-${content.contentId}`,
-			title: content.title,
-			description: content.description,
-			contentUrl: content.contentUrl,
-		};
 	}
 }

--- a/functions/src/controllers/PlacesController.ts
+++ b/functions/src/controllers/PlacesController.ts
@@ -19,7 +19,14 @@ export class PlacesController extends BaseController {
 		const router = super.register(basePath);
 		this.registerRoute(router, "POST", "/:id/hold", this.hold, [
 			fw.params.InstantValidator(
-				[params.headerBearerTokenValidator(), validators.param("id").isString().notEmpty()],
+				[
+					params.headerBearerTokenValidator(),
+					validators
+						.param("id")
+						.isString()
+						.notEmpty()
+						.matches(/^[^/]+$/),
+				],
 				(context) =>
 					({
 						authorization: context.req.headers.authorization,
@@ -30,7 +37,14 @@ export class PlacesController extends BaseController {
 
 		this.registerRoute(router, "POST", "/:id/release", this.release, [
 			fw.params.InstantValidator(
-				[params.headerBearerTokenValidator(), validators.param("id").isString().notEmpty()],
+				[
+					params.headerBearerTokenValidator(),
+					validators
+						.param("id")
+						.isString()
+						.notEmpty()
+						.matches(/^[^/]+$/),
+				],
 				(context) =>
 					({
 						authorization: context.req.headers.authorization,
@@ -41,7 +55,14 @@ export class PlacesController extends BaseController {
 
 		this.registerRoute(router, "POST", "/:id/play/start", this.startPlay, [
 			fw.params.InstantValidator(
-				[params.headerBearerTokenValidator(), validators.param("id").isString().notEmpty()],
+				[
+					params.headerBearerTokenValidator(),
+					validators
+						.param("id")
+						.isString()
+						.notEmpty()
+						.matches(/^[^/]+$/),
+				],
 				(context) =>
 					({
 						authorization: context.req.headers.authorization,

--- a/functions/src/controllers/PlacesController.ts
+++ b/functions/src/controllers/PlacesController.ts
@@ -90,11 +90,9 @@ export class PlacesController extends BaseController {
 				holdPlaceId: target.holdPlaceId,
 				placeId: target.placeId,
 				playId: target.currentPlayId,
-				gameCode: buildAkashicGameCode(target.holdPlaceId, content.contentCode),
 				gameTitle: content.title,
 				gameDescription: content.description,
 				contentUrl: content.contentUrl,
-				inputAdapter: content.inputAdapter,
 				expireAt: target.expireAt?.toDate().toISOString(),
 				joinPath: `/play/${encodeURIComponent(target.holdPlaceId)}`,
 			};
@@ -129,11 +127,9 @@ export class PlacesController extends BaseController {
 			holdPlaceId: storedPlay.holdPlaceId,
 			placeId: storedPlay.placeId,
 			playId: storedPlay.currentPlayId,
-			gameCode: buildAkashicGameCode(storedPlay.holdPlaceId, storedContent.contentCode),
 			gameTitle: storedContent.title,
 			gameDescription: storedContent.description,
 			contentUrl: storedContent.contentUrl,
-			inputAdapter: storedContent.inputAdapter,
 			expireAt: storedPlay.expireAt?.toDate().toISOString(),
 			joinPath: `/play/${encodeURIComponent(storedPlay.holdPlaceId)}`,
 		};

--- a/functions/src/controllers/PlacesController.ts
+++ b/functions/src/controllers/PlacesController.ts
@@ -4,7 +4,8 @@ import * as validators from "express-validator";
 import * as fw from "../fw";
 import * as params from "../params";
 import { Router } from "express";
-import { getCurrentHoldPlacePlayInfo, holdPlace, releaseHoldPlace, setHoldPlacePlay } from "../stores";
+import { holdPlace, releaseHoldPlace, setHoldPlacePlay } from "../stores";
+import { getCurrentHoldPlacePlayInfo } from "../resolvers/holdPlaces";
 import { AkashicSystemClient, loadAkashicSystemConfig } from "../services/akashicSystem";
 import { buildAkashicGameCode, DEFAULT_SCRAMBLE_PLAY_CONTENT, resolvePlayContentInfo } from "../services/playContent";
 

--- a/functions/src/controllers/PlacesController.ts
+++ b/functions/src/controllers/PlacesController.ts
@@ -4,7 +4,9 @@ import * as validators from "express-validator";
 import * as fw from "../fw";
 import * as params from "../params";
 import { Router } from "express";
-import { holdPlace, releaseHoldPlace } from "../stores";
+import { getCurrentHoldPlacePlayInfo, holdPlace, releaseHoldPlace, setHoldPlacePlay } from "../stores";
+import { AkashicSystemClient, loadAkashicSystemConfig } from "../services/akashicSystem";
+import { GameDriveClient, loadGameDriveConfig } from "../services/gameDrive";
 
 interface IdParams {
 	authorization: string;
@@ -36,6 +38,17 @@ export class PlacesController extends BaseController {
 			),
 		]);
 
+		this.registerRoute(router, "POST", "/:id/play/start", this.startPlay, [
+			fw.params.InstantValidator(
+				[params.headerBearerTokenValidator(), validators.param("id").isString().notEmpty()],
+				(context) =>
+					({
+						authorization: context.req.headers.authorization,
+						id: context.req.params.id as string,
+					}) as IdParams,
+			),
+		]);
+
 		return router;
 	}
 
@@ -52,10 +65,106 @@ export class PlacesController extends BaseController {
 	async release(context: Context) {
 		const p = context.params as IdParams;
 		const verifyResult = await this.verify(p.authorization);
-		await releaseHoldPlace(this.app.firestore, {
+		const endedHoldPlace = await releaseHoldPlace(this.app.firestore, {
 			placeId: p.id,
 			holdUserId: verifyResult.uid,
 		});
+		if (endedHoldPlace?.currentPlayId) {
+			await this.stopAkashicPlayIfConfigured(endedHoldPlace.currentPlayId);
+		}
 		return { result: "ok" };
+	}
+
+	async startPlay(context: Context) {
+		const p = context.params as IdParams;
+		const verifyResult = await this.verify(p.authorization);
+		const config = loadAkashicSystemConfig();
+		const target = await getCurrentHoldPlacePlayInfo(this.app.firestore, {
+			placeId: p.id,
+			holdUserId: verifyResult.uid,
+			requireOwner: true,
+		});
+		if (target.currentPlayId) {
+			return {
+				holdPlaceId: target.holdPlaceId,
+				placeId: target.placeId,
+				playId: target.currentPlayId,
+				gameCode: target.currentPlayGameCode ?? config.defaultGameCode,
+				gameTitle: target.currentPlayTitle ?? config.defaultGameTitle,
+				gameDescription: target.currentPlayDescription ?? config.defaultGameDescription,
+				contentUrl: target.currentPlayContentUrl ?? config.defaultContentUrl,
+				inputAdapter: target.currentPlayInputAdapter ?? config.defaultInputAdapter,
+				expireAt: target.expireAt?.toDate().toISOString(),
+				joinPath: `/play/${encodeURIComponent(target.holdPlaceId)}`,
+			};
+		}
+
+		const game = await this.resolveGameConfig(config);
+		const system = new AkashicSystemClient(config);
+		const gameCode = `scramble-${target.holdPlaceId}-${game.gameCode}`;
+		const createdPlay = await system.createPlay(gameCode);
+		let storedPlay;
+		try {
+			storedPlay = await setHoldPlacePlay(this.app.firestore, {
+				holdPlaceId: target.holdPlaceId,
+				holdUserId: verifyResult.uid,
+				systemPlayId: createdPlay.id,
+				gameCode,
+				gameTitle: game.title,
+				gameDescription: game.description,
+				contentUrl: game.contentUrl,
+				inputAdapter: config.defaultInputAdapter,
+				activeUserId: verifyResult.uid,
+			});
+
+			if (storedPlay.currentPlayId !== createdPlay.id) {
+				await system.stopPlay(createdPlay.id);
+			}
+		} catch (error) {
+			await system.stopPlay(createdPlay.id);
+			throw error;
+		}
+
+		return {
+			holdPlaceId: storedPlay.holdPlaceId,
+			placeId: storedPlay.placeId,
+			playId: storedPlay.currentPlayId,
+			gameCode: storedPlay.currentPlayGameCode ?? gameCode,
+			gameTitle: storedPlay.currentPlayTitle ?? config.defaultGameTitle,
+			gameDescription: storedPlay.currentPlayDescription ?? config.defaultGameDescription,
+			contentUrl: storedPlay.currentPlayContentUrl ?? config.defaultContentUrl,
+			inputAdapter: storedPlay.currentPlayInputAdapter ?? config.defaultInputAdapter,
+			expireAt: storedPlay.expireAt?.toDate().toISOString(),
+			joinPath: `/play/${encodeURIComponent(storedPlay.holdPlaceId)}`,
+		};
+	}
+
+	private async stopAkashicPlayIfConfigured(playId: string) {
+		if (!process.env.AKASHIC_SYSTEM_API_KEY) return;
+		try {
+			await new AkashicSystemClient().stopPlay(playId);
+		} catch (error) {
+			console.warn(error);
+		}
+	}
+
+	private async resolveGameConfig(config: ReturnType<typeof loadAkashicSystemConfig>) {
+		const gameDriveConfig = loadGameDriveConfig();
+		if (!gameDriveConfig.contentId) {
+			return {
+				gameCode: config.defaultGameCode,
+				title: config.defaultGameTitle,
+				description: config.defaultGameDescription,
+				contentUrl: config.defaultContentUrl,
+			};
+		}
+
+		const content = await new GameDriveClient(gameDriveConfig).resolveContent(gameDriveConfig.contentId);
+		return {
+			gameCode: `game-drive-${content.contentId}`,
+			title: content.title,
+			description: content.description,
+			contentUrl: content.contentUrl,
+		};
 	}
 }

--- a/functions/src/controllers/PlacesController.ts
+++ b/functions/src/controllers/PlacesController.ts
@@ -89,11 +89,11 @@ export class PlacesController extends BaseController {
 				holdPlaceId: target.holdPlaceId,
 				placeId: target.placeId,
 				playId: target.currentPlayId,
-				gameCode: target.currentPlayGameCode ?? config.defaultGameCode,
-				gameTitle: target.currentPlayTitle ?? config.defaultGameTitle,
-				gameDescription: target.currentPlayDescription ?? config.defaultGameDescription,
-				contentUrl: target.currentPlayContentUrl ?? config.defaultContentUrl,
-				inputAdapter: target.currentPlayInputAdapter ?? config.defaultInputAdapter,
+				gameCode: target.gameCode ?? config.defaultGameCode,
+				gameTitle: target.gameTitle ?? config.defaultGameTitle,
+				gameDescription: target.gameDescription ?? config.defaultGameDescription,
+				contentUrl: target.contentUrl ?? config.defaultContentUrl,
+				inputAdapter: target.inputAdapter ?? config.defaultInputAdapter,
 				expireAt: target.expireAt?.toDate().toISOString(),
 				joinPath: `/play/${encodeURIComponent(target.holdPlaceId)}`,
 			};
@@ -109,12 +109,14 @@ export class PlacesController extends BaseController {
 				holdPlaceId: target.holdPlaceId,
 				holdUserId: verifyResult.uid,
 				systemPlayId: createdPlay.id,
+				providerId: game.providerId,
+				contentCode: game.contentCode,
 				gameCode,
 				gameTitle: game.title,
 				gameDescription: game.description,
 				contentUrl: game.contentUrl,
 				inputAdapter: config.defaultInputAdapter,
-				activeUserId: verifyResult.uid,
+				ownerUserId: verifyResult.uid,
 			});
 
 			if (storedPlay.currentPlayId !== createdPlay.id) {
@@ -129,11 +131,11 @@ export class PlacesController extends BaseController {
 			holdPlaceId: storedPlay.holdPlaceId,
 			placeId: storedPlay.placeId,
 			playId: storedPlay.currentPlayId,
-			gameCode: storedPlay.currentPlayGameCode ?? gameCode,
-			gameTitle: storedPlay.currentPlayTitle ?? config.defaultGameTitle,
-			gameDescription: storedPlay.currentPlayDescription ?? config.defaultGameDescription,
-			contentUrl: storedPlay.currentPlayContentUrl ?? config.defaultContentUrl,
-			inputAdapter: storedPlay.currentPlayInputAdapter ?? config.defaultInputAdapter,
+			gameCode: storedPlay.gameCode ?? gameCode,
+			gameTitle: storedPlay.gameTitle ?? config.defaultGameTitle,
+			gameDescription: storedPlay.gameDescription ?? config.defaultGameDescription,
+			contentUrl: storedPlay.contentUrl ?? config.defaultContentUrl,
+			inputAdapter: storedPlay.inputAdapter ?? config.defaultInputAdapter,
 			expireAt: storedPlay.expireAt?.toDate().toISOString(),
 			joinPath: `/play/${encodeURIComponent(storedPlay.holdPlaceId)}`,
 		};
@@ -152,6 +154,8 @@ export class PlacesController extends BaseController {
 		const gameDriveConfig = loadGameDriveConfig();
 		if (!gameDriveConfig.contentId) {
 			return {
+				providerId: "akashic-system",
+				contentCode: config.defaultGameCode,
 				gameCode: config.defaultGameCode,
 				title: config.defaultGameTitle,
 				description: config.defaultGameDescription,
@@ -161,6 +165,8 @@ export class PlacesController extends BaseController {
 
 		const content = await new GameDriveClient(gameDriveConfig).resolveContent(gameDriveConfig.contentId);
 		return {
+			providerId: "akashic-game-drive",
+			contentCode: content.contentId,
 			gameCode: `game-drive-${content.contentId}`,
 			title: content.title,
 			description: content.description,

--- a/functions/src/controllers/index.ts
+++ b/functions/src/controllers/index.ts
@@ -1,4 +1,5 @@
 export * from "./SystemController";
 export * from "./UsersController";
 export * from "./PlacesController";
+export * from "./HoldPlacesController";
 export * from "./ManageController";

--- a/functions/src/fw/App.ts
+++ b/functions/src/fw/App.ts
@@ -6,6 +6,21 @@ import { AppConfig } from "./config";
 
 type expressVerifyFunction = (req: IncomingMessage, res: ServerResponse, buf: Buffer, encoding: string) => void;
 
+const SCRAMBLE_HOSTING_PREVIEW_ORIGIN = /^https:\/\/akashic-scramble--[a-z0-9-]+\.web\.app$/;
+
+function isAllowedCorsOrigin(origin: string) {
+	if (origin === "https://akashic-scramble.web.app") return true;
+	if (origin === "https://akashic-scramble.firebaseapp.com") return true;
+	if (SCRAMBLE_HOSTING_PREVIEW_ORIGIN.test(origin)) return true;
+
+	try {
+		const url = new URL(origin);
+		return (url.hostname === "localhost" || url.hostname === "127.0.0.1") && url.protocol === "http:";
+	} catch {
+		return false;
+	}
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export class App<T extends AppConfig> {
 	readonly app: express.Express;
@@ -20,7 +35,11 @@ export class App<T extends AppConfig> {
 
 	enableCors(...customHeaders: string[]) {
 		this.app.use((req, res, next) => {
-			res.header("Access-Control-Allow-Origin", req.headers.origin);
+			const origin = req.headers.origin;
+			if (typeof origin === "string" && isAllowedCorsOrigin(origin)) {
+				res.header("Access-Control-Allow-Origin", origin);
+				res.header("Vary", "Origin");
+			}
 			res.header(
 				"Access-Control-Allow-Headers",
 				["Origin", "X-Requested-With", "Content-Type", "Accept", "Authorization"]

--- a/functions/src/fw/App.ts
+++ b/functions/src/fw/App.ts
@@ -27,7 +27,11 @@ export class App<T extends AppConfig> {
 					.concat(customHeaders ?? [])
 					.join(", "),
 			);
-			res.header("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE");
+			res.header("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE, OPTIONS");
+			if (req.method === "OPTIONS") {
+				res.sendStatus(204);
+				return;
+			}
 			next();
 		});
 	}

--- a/functions/src/fw/App.ts
+++ b/functions/src/fw/App.ts
@@ -6,21 +6,6 @@ import { AppConfig } from "./config";
 
 type expressVerifyFunction = (req: IncomingMessage, res: ServerResponse, buf: Buffer, encoding: string) => void;
 
-const SCRAMBLE_HOSTING_PREVIEW_ORIGIN = /^https:\/\/akashic-scramble--[a-z0-9-]+\.web\.app$/;
-
-function isAllowedCorsOrigin(origin: string) {
-	if (origin === "https://akashic-scramble.web.app") return true;
-	if (origin === "https://akashic-scramble.firebaseapp.com") return true;
-	if (SCRAMBLE_HOSTING_PREVIEW_ORIGIN.test(origin)) return true;
-
-	try {
-		const url = new URL(origin);
-		return (url.hostname === "localhost" || url.hostname === "127.0.0.1") && url.protocol === "http:";
-	} catch {
-		return false;
-	}
-}
-
 // eslint-disable-next-line import/prefer-default-export
 export class App<T extends AppConfig> {
 	readonly app: express.Express;
@@ -35,11 +20,7 @@ export class App<T extends AppConfig> {
 
 	enableCors(...customHeaders: string[]) {
 		this.app.use((req, res, next) => {
-			const origin = req.headers.origin;
-			if (typeof origin === "string" && isAllowedCorsOrigin(origin)) {
-				res.header("Access-Control-Allow-Origin", origin);
-				res.header("Vary", "Origin");
-			}
+			res.header("Access-Control-Allow-Origin", req.headers.origin);
 			res.header(
 				"Access-Control-Allow-Headers",
 				["Origin", "X-Requested-With", "Content-Type", "Accept", "Authorization"]

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,6 +9,7 @@ import { AppConfig, Config } from "./config";
 import * as fw from "./fw";
 import { register } from "./register";
 import { expireHoldPlace } from "./stores";
+import { getExpirableHoldPlacePlayInfo } from "./resolvers/holdPlaces";
 import { AkashicSystemClient } from "./services/akashicSystem";
 
 let app: App | undefined = undefined;
@@ -45,6 +46,19 @@ function processRequest(app: App, apiKey: string | undefined, request: Request, 
 	}
 	return app.app(request, response);
 }
+
+function shouldStopAkashicPlay(status: string) {
+	return status === "preparing" || status === "running";
+}
+
+async function stopAkashicPlayIfNeeded(playId: string) {
+	const system = new AkashicSystemClient();
+	const play = await system.getPlay(playId);
+	if (shouldStopAkashicPlay(play.status)) {
+		await system.stopPlay(playId);
+	}
+}
+
 export const api = onRequest({ region: "asia-northeast1" }, (request, response) => {
 	if (app == null) {
 		return fw
@@ -72,16 +86,24 @@ export const expireHoldPlaces = onSchedule({ region: "asia-northeast1", schedule
 	if (snapshot.empty) return;
 
 	for (const doc of snapshot.docs) {
-		const endedHoldPlace = await expireHoldPlace(firestore, {
-			holdPlaceId: doc.id,
-			now,
-		});
-		if (endedHoldPlace?.currentPlayId && process.env.AKASHIC_SYSTEM_API_KEY) {
-			try {
-				await new AkashicSystemClient().stopPlay(endedHoldPlace.currentPlayId);
-			} catch (error) {
-				console.warn(error);
+		try {
+			const playInfo = await getExpirableHoldPlacePlayInfo(firestore, {
+				holdPlaceId: doc.id,
+				now,
+			});
+			if (!playInfo) continue;
+
+			if (playInfo.currentPlayId) {
+				await stopAkashicPlayIfNeeded(playInfo.currentPlayId);
 			}
+
+			await expireHoldPlace(firestore, {
+				holdPlaceId: doc.id,
+				now,
+				currentPlayId: playInfo.currentPlayId,
+			});
+		} catch (error) {
+			console.warn(`Failed to expire holdPlace ${doc.id}`, error);
 		}
 	}
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,6 +9,7 @@ import { AppConfig, Config } from "./config";
 import * as fw from "./fw";
 import { register } from "./register";
 import { expireHoldPlace } from "./stores";
+import { AkashicSystemClient } from "./services/akashicSystem";
 
 let app: App | undefined = undefined;
 let firebaseApp: FirebaseApp | undefined = undefined;
@@ -71,9 +72,16 @@ export const expireHoldPlaces = onSchedule({ region: "asia-northeast1", schedule
 	if (snapshot.empty) return;
 
 	for (const doc of snapshot.docs) {
-		await expireHoldPlace(firestore, {
+		const endedHoldPlace = await expireHoldPlace(firestore, {
 			holdPlaceId: doc.id,
 			now,
 		});
+		if (endedHoldPlace?.currentPlayId && process.env.AKASHIC_SYSTEM_API_KEY) {
+			try {
+				await new AkashicSystemClient().stopPlay(endedHoldPlace.currentPlayId);
+			} catch (error) {
+				console.warn(error);
+			}
+		}
 	}
 });

--- a/functions/src/register.ts
+++ b/functions/src/register.ts
@@ -10,6 +10,7 @@ export function register(app: App) {
 		"/": controllers.SystemController,
 		"/users": controllers.UsersController,
 		"/places": controllers.PlacesController,
+		"/holdPlaces": controllers.HoldPlacesController,
 		"/manage": controllers.ManageController,
 	});
 

--- a/functions/src/register.ts
+++ b/functions/src/register.ts
@@ -4,7 +4,6 @@ import * as fw from "./fw";
 
 export function register(app: App) {
 	app.enableCors("X-API-KEY");
-	app.enableCredentials();
 
 	app.register({
 		"/": controllers.SystemController,

--- a/functions/src/resolvers/holdPlaces.ts
+++ b/functions/src/resolvers/holdPlaces.ts
@@ -1,0 +1,128 @@
+import { Firestore, Timestamp } from "firebase-admin/firestore";
+import * as fw from "../fw";
+import { HoldPlace, Place, Play } from "../types/firestore";
+
+export interface HoldPlacePlayInfo {
+	holdPlaceId: string;
+	placeId: string;
+	holdUserId?: string;
+	currentPlayId?: string;
+	providerId?: string;
+	contentCode?: string;
+	contentUrl?: string;
+	ownerUserId?: string;
+	expireAt?: Timestamp;
+}
+
+function readHoldPlacePlaceId(holdPlaceId: string, holdPlaceData: Partial<HoldPlace>) {
+	if (typeof holdPlaceData.placeId === "string" && holdPlaceData.placeId) {
+		return holdPlaceData.placeId;
+	}
+	throw new fw.types.InternalServerError(`HoldPlace ${holdPlaceId} has no placeId`);
+}
+
+function normalizeHoldPlacePlayInfo(
+	holdPlaceId: string,
+	holdPlaceData: Partial<HoldPlace>,
+	playData?: Partial<Play>,
+): HoldPlacePlayInfo {
+	return {
+		holdPlaceId,
+		placeId: readHoldPlacePlaceId(holdPlaceId, holdPlaceData),
+		holdUserId: holdPlaceData.holdUserId,
+		currentPlayId: holdPlaceData.currentPlayId,
+		providerId: playData?.providerId,
+		contentCode: playData?.contentCode,
+		contentUrl: playData?.contentUrl,
+		ownerUserId: playData?.ownerUserId,
+		expireAt: holdPlaceData.expireAt,
+	};
+}
+
+export async function getCurrentHoldPlacePlayInfo(
+	firestore: Firestore,
+	input: {
+		placeId: string;
+		holdUserId?: string;
+		requireOwner: boolean;
+	},
+): Promise<HoldPlacePlayInfo> {
+	const placeSnap = await firestore.collection("places").doc(input.placeId).get();
+	if (!placeSnap.exists) {
+		throw new fw.types.NotFound(`Place with id ${input.placeId} not found`);
+	}
+
+	const placeData = placeSnap.data() as Partial<Place>;
+	const currentHoldPlaceId = placeData.currentHoldPlaceId;
+	if (!currentHoldPlaceId) {
+		throw new fw.types.BadRequest("Place is not held");
+	}
+
+	const holdPlaceSnap = await firestore.collection("holdPlaces").doc(currentHoldPlaceId).get();
+	if (!holdPlaceSnap.exists) {
+		throw new fw.types.NotFound(`HoldPlace with id ${currentHoldPlaceId} not found`);
+	}
+
+	const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
+	if (holdPlaceData.endedAt != null) {
+		throw new fw.types.BadRequest("HoldPlace is already ended");
+	}
+	const holdUserId = holdPlaceData.holdUserId;
+	if (input.requireOwner && holdUserId && holdUserId !== input.holdUserId) {
+		throw new fw.types.Forbidden("HoldPlace is owned by another user");
+	}
+
+	const currentPlayId = holdPlaceData.currentPlayId;
+	if (!currentPlayId) {
+		return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData);
+	}
+	const playSnap = await firestore.collection("plays").doc(currentPlayId).get();
+	if (!playSnap.exists) {
+		throw new fw.types.InternalServerError(`Play with id ${currentPlayId} not found`);
+	}
+	return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData, playSnap.data() as Partial<Play>);
+}
+
+export async function getHoldPlacePlayInfo(
+	firestore: Firestore,
+	input: {
+		holdPlaceId: string;
+	},
+): Promise<HoldPlacePlayInfo> {
+	const holdPlaceSnap = await firestore.collection("holdPlaces").doc(input.holdPlaceId).get();
+	if (!holdPlaceSnap.exists) {
+		throw new fw.types.NotFound(`HoldPlace with id ${input.holdPlaceId} not found`);
+	}
+
+	const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
+	if (holdPlaceData.endedAt != null) {
+		throw new fw.types.BadRequest("HoldPlace is already ended");
+	}
+	const playInfo = normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData);
+	if (!playInfo.currentPlayId) {
+		throw new fw.types.BadRequest("Play is not started");
+	}
+	const playSnap = await firestore.collection("plays").doc(playInfo.currentPlayId).get();
+	if (!playSnap.exists) {
+		throw new fw.types.InternalServerError(`Play with id ${playInfo.currentPlayId} not found`);
+	}
+	return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData, playSnap.data() as Partial<Play>);
+}
+
+export async function getExpirableHoldPlacePlayInfo(
+	firestore: Firestore,
+	input: {
+		holdPlaceId: string;
+		now: Timestamp;
+	},
+): Promise<HoldPlacePlayInfo | null> {
+	const holdPlaceSnap = await firestore.collection("holdPlaces").doc(input.holdPlaceId).get();
+	if (!holdPlaceSnap.exists) return null;
+
+	const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
+	if (holdPlaceData.endedAt != null) return null;
+	if (holdPlaceData.expireAt === undefined) return null;
+	if (holdPlaceData.expireAt.toMillis() > input.now.toMillis()) return null;
+
+	return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData);
+}

--- a/functions/src/resolvers/index.ts
+++ b/functions/src/resolvers/index.ts
@@ -1,4 +1,5 @@
 import * as users from "./users";
 import * as manage from "./manage";
+import * as holdPlaces from "./holdPlaces";
 
-export { users, manage };
+export { users, manage, holdPlaces };

--- a/functions/src/services/akashicSystem.ts
+++ b/functions/src/services/akashicSystem.ts
@@ -1,3 +1,5 @@
+import * as fw from "../fw";
+
 export type AkashicExecutionMode = "active" | "passive";
 
 export interface AkashicPlay {
@@ -51,20 +53,14 @@ const passivePermission: AkashicPermission = {
 	maxEventPriority: 2,
 };
 
-function normalizeBaseUrl(value: string) {
-	return value.trim().replace(/\/+$/, "");
-}
-
 export function loadAkashicSystemConfig(): AkashicSystemConfig {
 	const apiKey = process.env.AKASHIC_SYSTEM_API_KEY;
 	if (!apiKey) {
-		throw new Error("AKASHIC_SYSTEM_API_KEY is not configured.");
+		throw new fw.types.ServiceUnavailableError("Akashic System is not configured.");
 	}
 
 	return {
-		apiBaseUrl: normalizeBaseUrl(
-			process.env.AKASHIC_SYSTEM_API_BASE_URL ?? "https://akashic-system.shinonomekazan.com/api",
-		),
+		apiBaseUrl: process.env.AKASHIC_SYSTEM_API_BASE_URL ?? "https://akashic-system.shinonomekazan.com/api",
 		apiKey,
 		gamePageUrl:
 			process.env.AKASHIC_SYSTEM_GAME_PAGE_URL ??
@@ -87,15 +83,14 @@ async function requestJson<T>(
 		},
 		body: payload,
 	});
-	const text = await response.text();
 	let json: T;
 	try {
-		json = text ? (JSON.parse(text) as T) : ({} as T);
-	} catch (error) {
-		throw new Error(`Akashic System returned invalid JSON: ${text.slice(0, 120)}`);
+		json = (await response.json()) as T;
+	} catch {
+		throw new Error("Akashic System returned invalid JSON.");
 	}
 	if (!response.ok) {
-		throw new Error(`Akashic System API error: HTTP ${response.status} ${text.slice(0, 120)}`);
+		throw new Error(`Akashic System API error: HTTP ${response.status}`);
 	}
 	return json;
 }
@@ -122,6 +117,10 @@ export class AkashicSystemClient {
 
 	createPlay(gameCode: string) {
 		return this.request<AkashicPlay>("POST", "/v1.0/plays", { gameCode });
+	}
+
+	getPlay(playId: string) {
+		return this.request<AkashicPlay>("GET", `/v1.0/plays/${encodeURIComponent(playId)}`);
 	}
 
 	createToken(playId: string, userId: string, mode: AkashicExecutionMode) {

--- a/functions/src/services/akashicSystem.ts
+++ b/functions/src/services/akashicSystem.ts
@@ -1,0 +1,168 @@
+import * as http from "http";
+import * as https from "https";
+
+export type AkashicExecutionMode = "active" | "passive";
+
+export interface AkashicPlay {
+	id: string;
+	gameCode: string;
+	status: string;
+}
+
+export interface AkashicPlayToken {
+	value: string;
+	url: string;
+}
+
+export interface AkashicSystemConfig {
+	apiBaseUrl: string;
+	apiKey: string;
+	gamePageUrl: string;
+	defaultGameCode: string;
+	defaultGameTitle: string;
+	defaultGameDescription: string;
+	defaultContentUrl: string;
+	defaultInputAdapter: string;
+}
+
+export interface AkashicPermission {
+	writeTick?: boolean;
+	readTick?: boolean;
+	subscribeTick?: boolean;
+	sendEvent?: boolean;
+	subscribeEvent?: boolean;
+	maxEventPriority?: number;
+}
+
+interface ApiResponse<T> {
+	meta: {
+		status: number;
+		errorCode?: string | number;
+		errorMessage?: string;
+	};
+	data: T;
+}
+
+const browserActivePermission: AkashicPermission = {
+	writeTick: true,
+	readTick: true,
+	subscribeTick: true,
+	sendEvent: true,
+	subscribeEvent: true,
+	maxEventPriority: 0,
+};
+
+const passivePermission: AkashicPermission = {
+	readTick: true,
+	subscribeTick: true,
+	sendEvent: true,
+	maxEventPriority: 2,
+};
+
+function normalizeBaseUrl(value: string) {
+	return value.trim().replace(/\/+$/, "");
+}
+
+export function loadAkashicSystemConfig(): AkashicSystemConfig {
+	const apiKey = process.env.AKASHIC_SYSTEM_API_KEY;
+	if (!apiKey) {
+		throw new Error("AKASHIC_SYSTEM_API_KEY is not configured.");
+	}
+
+	return {
+		apiBaseUrl: normalizeBaseUrl(process.env.AKASHIC_SYSTEM_API_BASE_URL ?? "https://akashic-system.shinonomekazan.com/api"),
+		apiKey,
+		gamePageUrl: process.env.AKASHIC_SYSTEM_GAME_PAGE_URL ?? "https://akashic-system.shinonomekazan.com/contents/index.html",
+		defaultGameCode: process.env.SCRAMBLE_AKASHIC_GAME_CODE ?? "rocket-game",
+		defaultGameTitle: process.env.SCRAMBLE_AKASHIC_GAME_TITLE ?? "Rocket Game",
+		defaultGameDescription: process.env.SCRAMBLE_AKASHIC_GAME_DESCRIPTION ?? "",
+		defaultContentUrl: process.env.SCRAMBLE_AKASHIC_CONTENT_URL ?? "/contents/rocket-game/content.json",
+		defaultInputAdapter: process.env.SCRAMBLE_AKASHIC_INPUT_ADAPTER ?? "rocket-game",
+	};
+}
+
+function requestJson<T>(url: string, options: https.RequestOptions, body?: unknown): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const parsedUrl = new URL(url);
+		const transport = parsedUrl.protocol === "http:" ? http : https;
+		const payload = body == null ? undefined : JSON.stringify(body);
+		const request = transport.request(
+			parsedUrl,
+			{
+				...options,
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/json; charset=utf-8",
+					...(payload != null ? { "Content-Length": Buffer.byteLength(payload) } : {}),
+					...(options.headers ?? {}),
+				},
+			},
+			(response) => {
+				const chunks: Buffer[] = [];
+				response.on("data", (chunk: Buffer) => chunks.push(chunk));
+				response.on("end", () => {
+					const text = Buffer.concat(chunks).toString("utf8");
+					let json: T;
+					try {
+						json = text ? (JSON.parse(text) as T) : ({} as T);
+					} catch (error) {
+						reject(new Error(`Akashic System returned invalid JSON: ${text.slice(0, 120)}`));
+						return;
+					}
+					if (response.statusCode == null || response.statusCode < 200 || response.statusCode >= 300) {
+						reject(new Error(`Akashic System API error: HTTP ${response.statusCode} ${text.slice(0, 120)}`));
+						return;
+					}
+					resolve(json);
+				});
+			},
+		);
+		request.on("error", reject);
+		if (payload != null) request.write(payload);
+		request.end();
+	});
+}
+
+export class AkashicSystemClient {
+	readonly config: AkashicSystemConfig;
+
+	constructor(config: AkashicSystemConfig = loadAkashicSystemConfig()) {
+		this.config = config;
+	}
+
+	private request<T>(method: string, path: string, body?: unknown) {
+		return requestJson<ApiResponse<T>>(
+			`${this.config.apiBaseUrl}${path}`,
+			{
+				method,
+				headers: {
+					"X-API-Key": this.config.apiKey,
+				},
+			},
+			body,
+		).then((response) => response.data);
+	}
+
+	createPlay(gameCode: string) {
+		return this.request<AkashicPlay>("POST", "/v1.0/plays", { gameCode });
+	}
+
+	createToken(playId: string, userId: string, mode: AkashicExecutionMode) {
+		const permission = mode === "active" ? browserActivePermission : passivePermission;
+		return this.request<AkashicPlayToken>("POST", `/v1.0/plays/${encodeURIComponent(playId)}/tokens`, {
+			userId,
+			permission,
+		});
+	}
+
+	async stopPlay(playId: string) {
+		try {
+			await this.request<AkashicPlay>("DELETE", `/v1.0/plays/${encodeURIComponent(playId)}`);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			if (!message.includes("HTTP 404") && !message.includes("HTTP 409")) {
+				throw error;
+			}
+		}
+	}
+}

--- a/functions/src/services/akashicSystem.ts
+++ b/functions/src/services/akashicSystem.ts
@@ -1,6 +1,3 @@
-import * as http from "http";
-import * as https from "https";
-
 export type AkashicExecutionMode = "active" | "passive";
 
 export interface AkashicPlay {
@@ -81,46 +78,32 @@ export function loadAkashicSystemConfig(): AkashicSystemConfig {
 	};
 }
 
-function requestJson<T>(url: string, options: https.RequestOptions, body?: unknown): Promise<T> {
-	return new Promise((resolve, reject) => {
-		const parsedUrl = new URL(url);
-		const transport = parsedUrl.protocol === "http:" ? http : https;
-		const payload = body == null ? undefined : JSON.stringify(body);
-		const request = transport.request(
-			parsedUrl,
-			{
-				...options,
-				headers: {
-					Accept: "application/json",
-					"Content-Type": "application/json; charset=utf-8",
-					...(payload != null ? { "Content-Length": Buffer.byteLength(payload) } : {}),
-					...(options.headers ?? {}),
-				},
-			},
-			(response) => {
-				const chunks: Buffer[] = [];
-				response.on("data", (chunk: Buffer) => chunks.push(chunk));
-				response.on("end", () => {
-					const text = Buffer.concat(chunks).toString("utf8");
-					let json: T;
-					try {
-						json = text ? (JSON.parse(text) as T) : ({} as T);
-					} catch (error) {
-						reject(new Error(`Akashic System returned invalid JSON: ${text.slice(0, 120)}`));
-						return;
-					}
-					if (response.statusCode == null || response.statusCode < 200 || response.statusCode >= 300) {
-						reject(new Error(`Akashic System API error: HTTP ${response.statusCode} ${text.slice(0, 120)}`));
-						return;
-					}
-					resolve(json);
-				});
-			},
-		);
-		request.on("error", reject);
-		if (payload != null) request.write(payload);
-		request.end();
+async function requestJson<T>(
+	url: string,
+	options: { method: string; headers?: Record<string, string> },
+	body?: unknown,
+): Promise<T> {
+	const payload = body == null ? undefined : JSON.stringify(body);
+	const response = await fetch(url, {
+		method: options.method,
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/json; charset=utf-8",
+			...(options.headers ?? {}),
+		},
+		body: payload,
 	});
+	const text = await response.text();
+	let json: T;
+	try {
+		json = text ? (JSON.parse(text) as T) : ({} as T);
+	} catch (error) {
+		throw new Error(`Akashic System returned invalid JSON: ${text.slice(0, 120)}`);
+	}
+	if (!response.ok) {
+		throw new Error(`Akashic System API error: HTTP ${response.status} ${text.slice(0, 120)}`);
+	}
+	return json;
 }
 
 export class AkashicSystemClient {

--- a/functions/src/services/akashicSystem.ts
+++ b/functions/src/services/akashicSystem.ts
@@ -15,11 +15,6 @@ export interface AkashicSystemConfig {
 	apiBaseUrl: string;
 	apiKey: string;
 	gamePageUrl: string;
-	defaultGameCode: string;
-	defaultGameTitle: string;
-	defaultGameDescription: string;
-	defaultContentUrl: string;
-	defaultInputAdapter: string;
 }
 
 export interface AkashicPermission {
@@ -67,14 +62,13 @@ export function loadAkashicSystemConfig(): AkashicSystemConfig {
 	}
 
 	return {
-		apiBaseUrl: normalizeBaseUrl(process.env.AKASHIC_SYSTEM_API_BASE_URL ?? "https://akashic-system.shinonomekazan.com/api"),
+		apiBaseUrl: normalizeBaseUrl(
+			process.env.AKASHIC_SYSTEM_API_BASE_URL ?? "https://akashic-system.shinonomekazan.com/api",
+		),
 		apiKey,
-		gamePageUrl: process.env.AKASHIC_SYSTEM_GAME_PAGE_URL ?? "https://akashic-system.shinonomekazan.com/contents/index.html",
-		defaultGameCode: process.env.SCRAMBLE_AKASHIC_GAME_CODE ?? "rocket-game",
-		defaultGameTitle: process.env.SCRAMBLE_AKASHIC_GAME_TITLE ?? "Rocket Game",
-		defaultGameDescription: process.env.SCRAMBLE_AKASHIC_GAME_DESCRIPTION ?? "",
-		defaultContentUrl: process.env.SCRAMBLE_AKASHIC_CONTENT_URL ?? "/contents/rocket-game/content.json",
-		defaultInputAdapter: process.env.SCRAMBLE_AKASHIC_INPUT_ADAPTER ?? "rocket-game",
+		gamePageUrl:
+			process.env.AKASHIC_SYSTEM_GAME_PAGE_URL ??
+			"https://akashic-system.shinonomekazan.com/contents/index.html",
 	};
 }
 

--- a/functions/src/services/gameDrive.ts
+++ b/functions/src/services/gameDrive.ts
@@ -1,0 +1,146 @@
+import * as http from "http";
+import * as https from "https";
+
+interface ApiResponse<T> {
+	meta: {
+		status: number;
+		errorCode?: string | number;
+		errorMessage?: string;
+	};
+	data: T;
+}
+
+interface GameDriveContent {
+	id: string;
+	title: string;
+	description?: string;
+	contentJsonPath?: string | null;
+	state?: "ok" | "failed";
+	trusted?: boolean;
+}
+
+interface GetContentResponse {
+	content: GameDriveContent | null;
+}
+
+export interface GameDriveConfig {
+	apiBaseUrl: string;
+	apiKey?: string;
+	contentCdnBaseUrl: string;
+	contentId?: string;
+}
+
+export interface ResolvedGameDriveContent {
+	contentId: string;
+	title: string;
+	description: string;
+	contentUrl: string;
+}
+
+function normalizeBaseUrl(value: string) {
+	return value.trim().replace(/\/+$/, "");
+}
+
+function optionalEnv(key: string) {
+	const value = process.env[key]?.trim();
+	return value || undefined;
+}
+
+function joinPublicUrl(baseUrl: string, objectPath: string) {
+	const encodedPath = objectPath
+		.replace(/^\/+/, "")
+		.split("/")
+		.filter(Boolean)
+		.map((segment) => encodeURIComponent(segment))
+		.join("/");
+	return `${normalizeBaseUrl(baseUrl)}/${encodedPath}`;
+}
+
+export function loadGameDriveConfig(): GameDriveConfig {
+	return {
+		apiBaseUrl: normalizeBaseUrl(
+			process.env.GAME_DRIVE_API_BASE_URL ?? "https://asia-northeast1-akashic-game-drive.cloudfunctions.net/api",
+		),
+		apiKey: optionalEnv("GAME_DRIVE_API_KEY"),
+		contentCdnBaseUrl: normalizeBaseUrl(
+			process.env.GAME_DRIVE_CONTENT_CDN_BASE_URL ?? "https://drive.akashic.shinonomekazan.com",
+		),
+		contentId: optionalEnv("SCRAMBLE_GAME_DRIVE_CONTENT_ID"),
+	};
+}
+
+function requestJson<T>(url: string, options: https.RequestOptions): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const parsedUrl = new URL(url);
+		const transport = parsedUrl.protocol === "http:" ? http : https;
+		const request = transport.request(
+			parsedUrl,
+			{
+				...options,
+				headers: {
+					Accept: "application/json",
+					...(options.headers ?? {}),
+				},
+			},
+			(response) => {
+				const chunks: Buffer[] = [];
+				response.on("data", (chunk: Buffer) => chunks.push(chunk));
+				response.on("end", () => {
+					const text = Buffer.concat(chunks).toString("utf8");
+					let json: T;
+					try {
+						json = text ? (JSON.parse(text) as T) : ({} as T);
+					} catch (error) {
+						reject(new Error(`Game Drive API returned invalid JSON: ${text.slice(0, 120)}`));
+						return;
+					}
+					if (response.statusCode == null || response.statusCode < 200 || response.statusCode >= 300) {
+						reject(new Error(`Game Drive API error: HTTP ${response.statusCode} ${text.slice(0, 120)}`));
+						return;
+					}
+					resolve(json);
+				});
+			},
+		);
+		request.on("error", reject);
+		request.end();
+	});
+}
+
+export class GameDriveClient {
+	readonly config: GameDriveConfig;
+
+	constructor(config: GameDriveConfig = loadGameDriveConfig()) {
+		this.config = config;
+	}
+
+	private request<T>(path: string) {
+		return requestJson<ApiResponse<T>>(`${this.config.apiBaseUrl}${path}`, {
+			method: "GET",
+			headers: this.config.apiKey ? { "X-API-Key": this.config.apiKey } : {},
+		}).then((response) => response.data);
+	}
+
+	async resolveContent(contentId: string): Promise<ResolvedGameDriveContent> {
+		const response = await this.request<GetContentResponse>(`/contents/${encodeURIComponent(contentId)}`);
+		const content = response.content;
+		if (!content) {
+			throw new Error(`Game Drive content ${contentId} not found.`);
+		}
+		if (content.state && content.state !== "ok") {
+			throw new Error(`Game Drive content ${contentId} is not ready: ${content.state}`);
+		}
+		if (content.trusted === false) {
+			throw new Error(`Game Drive content ${contentId} is not trusted.`);
+		}
+		if (!content.contentJsonPath) {
+			throw new Error(`Game Drive content ${contentId} has no content.json.`);
+		}
+		return {
+			contentId: content.id,
+			title: content.title,
+			description: content.description ?? "",
+			contentUrl: joinPublicUrl(this.config.contentCdnBaseUrl, content.contentJsonPath),
+		};
+	}
+}

--- a/functions/src/services/gameDrive.ts
+++ b/functions/src/services/gameDrive.ts
@@ -24,7 +24,6 @@ export interface GameDriveConfig {
 	apiBaseUrl: string;
 	apiKey?: string;
 	contentCdnBaseUrl: string;
-	contentId?: string;
 }
 
 export interface ResolvedGameDriveContent {
@@ -62,7 +61,6 @@ export function loadGameDriveConfig(): GameDriveConfig {
 		contentCdnBaseUrl: normalizeBaseUrl(
 			process.env.GAME_DRIVE_CONTENT_CDN_BASE_URL ?? "https://drive.akashic.shinonomekazan.com",
 		),
-		contentId: optionalEnv("SCRAMBLE_GAME_DRIVE_CONTENT_ID"),
 	};
 }
 

--- a/functions/src/services/gameDrive.ts
+++ b/functions/src/services/gameDrive.ts
@@ -33,34 +33,21 @@ export interface ResolvedGameDriveContent {
 	contentUrl: string;
 }
 
-function normalizeBaseUrl(value: string) {
-	return value.trim().replace(/\/+$/, "");
-}
-
 function optionalEnv(key: string) {
 	const value = process.env[key]?.trim();
 	return value || undefined;
 }
 
 function joinPublicUrl(baseUrl: string, objectPath: string) {
-	const encodedPath = objectPath
-		.replace(/^\/+/, "")
-		.split("/")
-		.filter(Boolean)
-		.map((segment) => encodeURIComponent(segment))
-		.join("/");
-	return `${normalizeBaseUrl(baseUrl)}/${encodedPath}`;
+	return `${baseUrl}/${objectPath}`;
 }
 
 export function loadGameDriveConfig(): GameDriveConfig {
 	return {
-		apiBaseUrl: normalizeBaseUrl(
+		apiBaseUrl:
 			process.env.GAME_DRIVE_API_BASE_URL ?? "https://asia-northeast1-akashic-game-drive.cloudfunctions.net/api",
-		),
 		apiKey: optionalEnv("GAME_DRIVE_API_KEY"),
-		contentCdnBaseUrl: normalizeBaseUrl(
-			process.env.GAME_DRIVE_CONTENT_CDN_BASE_URL ?? "https://drive.akashic.shinonomekazan.com",
-		),
+		contentCdnBaseUrl: process.env.GAME_DRIVE_CONTENT_CDN_BASE_URL ?? "https://drive.akashic.shinonomekazan.com",
 	};
 }
 
@@ -72,15 +59,14 @@ async function requestJson<T>(url: string, options: { method: string; headers?: 
 			...(options.headers ?? {}),
 		},
 	});
-	const text = await response.text();
 	let json: T;
 	try {
-		json = text ? (JSON.parse(text) as T) : ({} as T);
-	} catch (error) {
-		throw new Error(`Game Drive API returned invalid JSON: ${text.slice(0, 120)}`);
+		json = (await response.json()) as T;
+	} catch {
+		throw new Error("Game Drive API returned invalid JSON.");
 	}
 	if (!response.ok) {
-		throw new Error(`Game Drive API error: HTTP ${response.status} ${text.slice(0, 120)}`);
+		throw new Error(`Game Drive API error: HTTP ${response.status}`);
 	}
 	return json;
 }

--- a/functions/src/services/gameDrive.ts
+++ b/functions/src/services/gameDrive.ts
@@ -1,6 +1,3 @@
-import * as http from "http";
-import * as https from "https";
-
 interface ApiResponse<T> {
 	meta: {
 		status: number;
@@ -69,42 +66,25 @@ export function loadGameDriveConfig(): GameDriveConfig {
 	};
 }
 
-function requestJson<T>(url: string, options: https.RequestOptions): Promise<T> {
-	return new Promise((resolve, reject) => {
-		const parsedUrl = new URL(url);
-		const transport = parsedUrl.protocol === "http:" ? http : https;
-		const request = transport.request(
-			parsedUrl,
-			{
-				...options,
-				headers: {
-					Accept: "application/json",
-					...(options.headers ?? {}),
-				},
-			},
-			(response) => {
-				const chunks: Buffer[] = [];
-				response.on("data", (chunk: Buffer) => chunks.push(chunk));
-				response.on("end", () => {
-					const text = Buffer.concat(chunks).toString("utf8");
-					let json: T;
-					try {
-						json = text ? (JSON.parse(text) as T) : ({} as T);
-					} catch (error) {
-						reject(new Error(`Game Drive API returned invalid JSON: ${text.slice(0, 120)}`));
-						return;
-					}
-					if (response.statusCode == null || response.statusCode < 200 || response.statusCode >= 300) {
-						reject(new Error(`Game Drive API error: HTTP ${response.statusCode} ${text.slice(0, 120)}`));
-						return;
-					}
-					resolve(json);
-				});
-			},
-		);
-		request.on("error", reject);
-		request.end();
+async function requestJson<T>(url: string, options: { method: string; headers?: Record<string, string> }): Promise<T> {
+	const response = await fetch(url, {
+		method: options.method,
+		headers: {
+			Accept: "application/json",
+			...(options.headers ?? {}),
+		},
 	});
+	const text = await response.text();
+	let json: T;
+	try {
+		json = text ? (JSON.parse(text) as T) : ({} as T);
+	} catch (error) {
+		throw new Error(`Game Drive API returned invalid JSON: ${text.slice(0, 120)}`);
+	}
+	if (!response.ok) {
+		throw new Error(`Game Drive API error: HTTP ${response.status} ${text.slice(0, 120)}`);
+	}
+	return json;
 }
 
 export class GameDriveClient {

--- a/functions/src/services/playContent.ts
+++ b/functions/src/services/playContent.ts
@@ -6,7 +6,6 @@ export interface PlayContentInfo {
 	title: string;
 	description: string;
 	contentUrl: string;
-	inputAdapter: string;
 }
 
 export interface PlayContentRef {
@@ -22,7 +21,6 @@ export const DEFAULT_SCRAMBLE_PLAY_CONTENT: PlayContentInfo = {
 	title: "Rocket Game",
 	description: "",
 	contentUrl: "/contents/rocket-game/content.json",
-	inputAdapter: "rocket-game",
 };
 
 export function buildAkashicGameCode(holdPlaceId: string, contentCode: string) {
@@ -38,7 +36,6 @@ export async function resolvePlayContentInfo(contentRef: PlayContentRef = {}): P
 			title: content.title,
 			description: content.description,
 			contentUrl: contentRef.contentUrl ?? content.contentUrl,
-			inputAdapter: DEFAULT_SCRAMBLE_PLAY_CONTENT.inputAdapter,
 		};
 	}
 

--- a/functions/src/services/playContent.ts
+++ b/functions/src/services/playContent.ts
@@ -1,0 +1,50 @@
+import { GameDriveClient, loadGameDriveConfig } from "./gameDrive";
+
+export interface PlayContentInfo {
+	providerId: string;
+	contentCode: string;
+	title: string;
+	description: string;
+	contentUrl: string;
+	inputAdapter: string;
+}
+
+export interface PlayContentRef {
+	providerId?: string;
+	contentCode?: string;
+	contentUrl?: string;
+}
+
+// Temporary fixed content until Scramble has Game Drive content selection.
+export const DEFAULT_SCRAMBLE_PLAY_CONTENT: PlayContentInfo = {
+	providerId: "akashic-system",
+	contentCode: "rocket-game",
+	title: "Rocket Game",
+	description: "",
+	contentUrl: "/contents/rocket-game/content.json",
+	inputAdapter: "rocket-game",
+};
+
+export function buildAkashicGameCode(holdPlaceId: string, contentCode: string) {
+	return `scramble-${holdPlaceId}-${contentCode}`;
+}
+
+export async function resolvePlayContentInfo(contentRef: PlayContentRef = {}): Promise<PlayContentInfo> {
+	if (contentRef.providerId === "akashic-game-drive" && contentRef.contentCode) {
+		const content = await new GameDriveClient(loadGameDriveConfig()).resolveContent(contentRef.contentCode);
+		return {
+			providerId: "akashic-game-drive",
+			contentCode: content.contentId,
+			title: content.title,
+			description: content.description,
+			contentUrl: contentRef.contentUrl ?? content.contentUrl,
+			inputAdapter: DEFAULT_SCRAMBLE_PLAY_CONTENT.inputAdapter,
+		};
+	}
+
+	return {
+		...DEFAULT_SCRAMBLE_PLAY_CONTENT,
+		contentCode: contentRef.contentCode ?? DEFAULT_SCRAMBLE_PLAY_CONTENT.contentCode,
+		contentUrl: contentRef.contentUrl ?? DEFAULT_SCRAMBLE_PLAY_CONTENT.contentUrl,
+	};
+}

--- a/functions/src/stores/index.ts
+++ b/functions/src/stores/index.ts
@@ -4,6 +4,26 @@ import { eraseUndefined } from "../utils";
 import * as fw from "../fw";
 import { HoldPlace, Place, PlaceBehaviour, PlaceHoldableTimeBehaviour } from "../types/firestore";
 
+export interface EndedHoldPlaceResult {
+	holdPlaceId: string;
+	placeId?: string;
+	currentPlayId?: string;
+}
+
+export interface HoldPlacePlayInfo {
+	holdPlaceId: string;
+	placeId: string;
+	holdUserId?: string;
+	currentPlayId?: string;
+	currentPlayGameCode?: string;
+	currentPlayTitle?: string;
+	currentPlayDescription?: string;
+	currentPlayContentUrl?: string;
+	currentPlayInputAdapter?: string;
+	activeUserId?: string;
+	expireAt?: Timestamp;
+}
+
 // PlaceBehaviour から holdableTime バリアントを絞り込むための型ガード
 function isPlaceHoldableTimeBehaviour(behaviour: PlaceBehaviour): behaviour is PlaceHoldableTimeBehaviour {
 	return behaviour.type === "holdableTime";
@@ -34,13 +54,13 @@ async function endHoldPlaceTransaction(
 	const holdPlaceRef = firestore.collection("holdPlaces").doc(input.holdPlaceId);
 	const holdPlaceSnap = await transaction.get(holdPlaceRef);
 	if (!holdPlaceSnap.exists) {
-		if (input.allowMissing) return false;
+		if (input.allowMissing) return null;
 		throw new fw.types.NotFound(`HoldPlace with id ${input.holdPlaceId} not found`);
 	}
 
 	const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
 	if (holdPlaceData.endedAt != null) {
-		if (input.allowAlreadyEnded) return false;
+		if (input.allowAlreadyEnded) return null;
 		throw new fw.types.Duplicate("HoldPlace is already ended");
 	}
 
@@ -49,12 +69,13 @@ async function endHoldPlaceTransaction(
 	}
 
 	if (input.expireAtRequired != null) {
-		if (holdPlaceData.expireAt === undefined) return false;
-		if (holdPlaceData.expireAt.toMillis() > input.expireAtRequired.toMillis()) return false;
+		if (holdPlaceData.expireAt === undefined) return null;
+		if (holdPlaceData.expireAt.toMillis() > input.expireAtRequired.toMillis()) return null;
 	}
 
 	const now = input.now ?? Timestamp.now();
 	const placeId = input.placeId ?? holdPlaceData.placeId;
+	const currentPlayId = typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
 	if (placeId != undefined) {
 		const placeRef = firestore.collection("places").doc(placeId);
 		const placeSnap = await transaction.get(placeRef);
@@ -78,7 +99,34 @@ async function endHoldPlaceTransaction(
 		}),
 	);
 
-	return true;
+	return {
+		holdPlaceId: holdPlaceRef.id,
+		placeId,
+		currentPlayId,
+	};
+}
+
+function normalizeHoldPlacePlayInfo(holdPlaceId: string, holdPlaceData: Partial<HoldPlace>): HoldPlacePlayInfo {
+	return {
+		holdPlaceId,
+		placeId: holdPlaceData.placeId ?? "",
+		holdUserId: typeof holdPlaceData.holdUserId === "string" ? holdPlaceData.holdUserId : undefined,
+		currentPlayId: typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined,
+		currentPlayGameCode:
+			typeof holdPlaceData.currentPlayGameCode === "string" ? holdPlaceData.currentPlayGameCode : undefined,
+		currentPlayTitle:
+			typeof holdPlaceData.currentPlayTitle === "string" ? holdPlaceData.currentPlayTitle : undefined,
+		currentPlayDescription:
+			typeof holdPlaceData.currentPlayDescription === "string"
+				? holdPlaceData.currentPlayDescription
+				: undefined,
+		currentPlayContentUrl:
+			typeof holdPlaceData.currentPlayContentUrl === "string" ? holdPlaceData.currentPlayContentUrl : undefined,
+		currentPlayInputAdapter:
+			typeof holdPlaceData.currentPlayInputAdapter === "string" ? holdPlaceData.currentPlayInputAdapter : undefined,
+		activeUserId: typeof holdPlaceData.activeUserId === "string" ? holdPlaceData.activeUserId : undefined,
+		expireAt: holdPlaceData.expireAt,
+	};
 }
 
 export function storeUser(firestore: Firestore, user: Omit<UserProfile, "createdAt" | "updatedAt">) {
@@ -195,7 +243,7 @@ export function releaseHoldPlace(
 			throw new fw.types.BadRequest("Place is not held");
 		}
 
-		await endHoldPlaceTransaction(firestore, transaction, {
+		return endHoldPlaceTransaction(firestore, transaction, {
 			holdPlaceId: currentHoldPlaceId,
 			holdUserId: input.holdUserId,
 			requireOwner: true,
@@ -213,7 +261,7 @@ export function expireHoldPlace(
 	},
 ) {
 	return firestore.runTransaction(async (transaction) => {
-		await endHoldPlaceTransaction(firestore, transaction, {
+		return endHoldPlaceTransaction(firestore, transaction, {
 			holdPlaceId: input.holdPlaceId,
 			requireOwner: false,
 			expireAtRequired: input.now,
@@ -221,5 +269,150 @@ export function expireHoldPlace(
 			allowMissing: true,
 			allowAlreadyEnded: true,
 		});
+	});
+}
+
+export async function getCurrentHoldPlacePlayInfo(
+	firestore: Firestore,
+	input: {
+		placeId: string;
+		holdUserId?: string;
+		requireOwner: boolean;
+	},
+): Promise<HoldPlacePlayInfo> {
+	const placeSnap = await firestore.collection("places").doc(input.placeId).get();
+	if (!placeSnap.exists) {
+		throw new fw.types.NotFound(`Place with id ${input.placeId} not found`);
+	}
+
+	const placeData = placeSnap.data() as Partial<Place>;
+	const currentHoldPlaceId =
+		typeof placeData.currentHoldPlaceId === "string" ? placeData.currentHoldPlaceId : undefined;
+	if (!currentHoldPlaceId) {
+		throw new fw.types.BadRequest("Place is not held");
+	}
+
+	const holdPlaceSnap = await firestore.collection("holdPlaces").doc(currentHoldPlaceId).get();
+	if (!holdPlaceSnap.exists) {
+		throw new fw.types.NotFound(`HoldPlace with id ${currentHoldPlaceId} not found`);
+	}
+
+	const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
+	if (holdPlaceData.endedAt != null) {
+		throw new fw.types.BadRequest("HoldPlace is already ended");
+	}
+	if (input.requireOwner && holdPlaceData.holdUserId && holdPlaceData.holdUserId !== input.holdUserId) {
+		throw new fw.types.Forbidden("HoldPlace is owned by another user");
+	}
+
+	return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData);
+}
+
+export function setHoldPlacePlay(
+	firestore: Firestore,
+	input: {
+		holdPlaceId: string;
+		holdUserId?: string;
+		systemPlayId: string;
+		gameCode: string;
+		gameTitle: string;
+		gameDescription: string;
+		contentUrl: string;
+		inputAdapter: string;
+		activeUserId: string;
+	},
+) {
+	return firestore.runTransaction(async (transaction) => {
+		const holdPlaceRef = firestore.collection("holdPlaces").doc(input.holdPlaceId);
+		const holdPlaceSnap = await transaction.get(holdPlaceRef);
+		if (!holdPlaceSnap.exists) {
+			throw new fw.types.NotFound(`HoldPlace with id ${input.holdPlaceId} not found`);
+		}
+
+		const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
+		if (holdPlaceData.endedAt != null) {
+			throw new fw.types.BadRequest("HoldPlace is already ended");
+		}
+		if (holdPlaceData.holdUserId && holdPlaceData.holdUserId !== input.holdUserId) {
+			throw new fw.types.Forbidden("HoldPlace is owned by another user");
+		}
+		if (typeof holdPlaceData.currentPlayId === "string") {
+			return normalizeHoldPlacePlayInfo(holdPlaceRef.id, holdPlaceData);
+		}
+
+		const now = Timestamp.now();
+		const nextData = {
+			currentPlayId: input.systemPlayId,
+			currentPlayGameCode: input.gameCode,
+			currentPlayTitle: input.gameTitle,
+			currentPlayDescription: input.gameDescription,
+			currentPlayContentUrl: input.contentUrl,
+			currentPlayInputAdapter: input.inputAdapter,
+			activeUserId: input.activeUserId,
+			updatedAt: now,
+		};
+		await transaction.update(holdPlaceRef, nextData);
+
+		return normalizeHoldPlacePlayInfo(holdPlaceRef.id, {
+			...holdPlaceData,
+			...nextData,
+		});
+	});
+}
+
+export async function getHoldPlacePlayInfo(
+	firestore: Firestore,
+	input: {
+		holdPlaceId: string;
+	},
+): Promise<HoldPlacePlayInfo> {
+	const holdPlaceSnap = await firestore.collection("holdPlaces").doc(input.holdPlaceId).get();
+	if (!holdPlaceSnap.exists) {
+		throw new fw.types.NotFound(`HoldPlace with id ${input.holdPlaceId} not found`);
+	}
+
+	const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
+	if (holdPlaceData.endedAt != null) {
+		throw new fw.types.BadRequest("HoldPlace is already ended");
+	}
+	const playInfo = normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData);
+	if (!playInfo.currentPlayId) {
+		throw new fw.types.BadRequest("Play is not started");
+	}
+	return playInfo;
+}
+
+export function clearHoldPlacePlay(
+	firestore: Firestore,
+	input: {
+		holdPlaceId: string;
+		holdUserId?: string;
+		requireOwner: boolean;
+	},
+) {
+	return firestore.runTransaction(async (transaction) => {
+		const holdPlaceRef = firestore.collection("holdPlaces").doc(input.holdPlaceId);
+		const holdPlaceSnap = await transaction.get(holdPlaceRef);
+		if (!holdPlaceSnap.exists) {
+			throw new fw.types.NotFound(`HoldPlace with id ${input.holdPlaceId} not found`);
+		}
+
+		const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
+		if (input.requireOwner && holdPlaceData.holdUserId && holdPlaceData.holdUserId !== input.holdUserId) {
+			throw new fw.types.Forbidden("HoldPlace is owned by another user");
+		}
+
+		const playInfo = normalizeHoldPlacePlayInfo(holdPlaceRef.id, holdPlaceData);
+		await transaction.update(holdPlaceRef, {
+			currentPlayId: FieldValue.delete(),
+			currentPlayGameCode: FieldValue.delete(),
+			currentPlayTitle: FieldValue.delete(),
+			currentPlayDescription: FieldValue.delete(),
+			currentPlayContentUrl: FieldValue.delete(),
+			currentPlayInputAdapter: FieldValue.delete(),
+			activeUserId: FieldValue.delete(),
+			updatedAt: Timestamp.now(),
+		});
+		return playInfo;
 	});
 }

--- a/functions/src/stores/index.ts
+++ b/functions/src/stores/index.ts
@@ -2,6 +2,7 @@ import { UserProfile } from "../types";
 import { Firestore, Timestamp, FieldValue, Transaction } from "firebase-admin/firestore";
 import { eraseUndefined } from "../utils";
 import * as fw from "../fw";
+import type { HoldPlacePlayInfo } from "../resolvers/holdPlaces";
 import {
 	HoldPlace,
 	Place,
@@ -16,18 +17,6 @@ export interface EndedHoldPlaceResult {
 	holdPlaceId: string;
 	placeId?: string;
 	currentPlayId?: string;
-}
-
-export interface HoldPlacePlayInfo {
-	holdPlaceId: string;
-	placeId: string;
-	holdUserId?: string;
-	currentPlayId?: string;
-	providerId?: string;
-	contentCode?: string;
-	contentUrl?: string;
-	ownerUserId?: string;
-	expireAt?: Timestamp;
 }
 
 // PlaceBehaviour から holdableTime バリアントを絞り込むための型ガード
@@ -63,6 +52,8 @@ async function endHoldPlaceTransaction(
 		now?: Timestamp;
 		allowMissing?: boolean;
 		allowAlreadyEnded?: boolean;
+		requireSameCurrentPlayId?: boolean;
+		expectedCurrentPlayId?: string;
 	},
 ) {
 	const holdPlaceRef = firestore.collection("holdPlaces").doc(input.holdPlaceId);
@@ -91,6 +82,7 @@ async function endHoldPlaceTransaction(
 	const now = input.now ?? Timestamp.now();
 	const placeId = input.placeId ?? holdPlaceData.placeId;
 	const currentPlayId = holdPlaceData.currentPlayId;
+	if (input.requireSameCurrentPlayId && currentPlayId !== input.expectedCurrentPlayId) return null;
 	const playRef = currentPlayId ? firestore.collection("plays").doc(currentPlayId) : undefined;
 	const playSnap = playRef ? await transaction.get(playRef) : undefined;
 	if (placeId != undefined) {
@@ -282,6 +274,7 @@ export function expireHoldPlace(
 	input: {
 		holdPlaceId: string;
 		now: Timestamp;
+		currentPlayId?: string;
 	},
 ) {
 	return firestore.runTransaction(async (transaction) => {
@@ -292,52 +285,10 @@ export function expireHoldPlace(
 			now: input.now,
 			allowMissing: true,
 			allowAlreadyEnded: true,
+			requireSameCurrentPlayId: true,
+			expectedCurrentPlayId: input.currentPlayId,
 		});
 	});
-}
-
-export async function getCurrentHoldPlacePlayInfo(
-	firestore: Firestore,
-	input: {
-		placeId: string;
-		holdUserId?: string;
-		requireOwner: boolean;
-	},
-): Promise<HoldPlacePlayInfo> {
-	const placeSnap = await firestore.collection("places").doc(input.placeId).get();
-	if (!placeSnap.exists) {
-		throw new fw.types.NotFound(`Place with id ${input.placeId} not found`);
-	}
-
-	const placeData = placeSnap.data() as Partial<Place>;
-	const currentHoldPlaceId = placeData.currentHoldPlaceId;
-	if (!currentHoldPlaceId) {
-		throw new fw.types.BadRequest("Place is not held");
-	}
-
-	const holdPlaceSnap = await firestore.collection("holdPlaces").doc(currentHoldPlaceId).get();
-	if (!holdPlaceSnap.exists) {
-		throw new fw.types.NotFound(`HoldPlace with id ${currentHoldPlaceId} not found`);
-	}
-
-	const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
-	if (holdPlaceData.endedAt != null) {
-		throw new fw.types.BadRequest("HoldPlace is already ended");
-	}
-	const holdUserId = holdPlaceData.holdUserId;
-	if (input.requireOwner && holdUserId && holdUserId !== input.holdUserId) {
-		throw new fw.types.Forbidden("HoldPlace is owned by another user");
-	}
-
-	const currentPlayId = holdPlaceData.currentPlayId;
-	if (!currentPlayId) {
-		return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData);
-	}
-	const playSnap = await firestore.collection("plays").doc(currentPlayId).get();
-	if (!playSnap.exists) {
-		throw new fw.types.InternalServerError(`Play with id ${currentPlayId} not found`);
-	}
-	return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData, playSnap.data() as Partial<Play>);
 }
 
 export function setHoldPlacePlay(
@@ -408,32 +359,6 @@ export function setHoldPlacePlay(
 			play,
 		);
 	});
-}
-
-export async function getHoldPlacePlayInfo(
-	firestore: Firestore,
-	input: {
-		holdPlaceId: string;
-	},
-): Promise<HoldPlacePlayInfo> {
-	const holdPlaceSnap = await firestore.collection("holdPlaces").doc(input.holdPlaceId).get();
-	if (!holdPlaceSnap.exists) {
-		throw new fw.types.NotFound(`HoldPlace with id ${input.holdPlaceId} not found`);
-	}
-
-	const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
-	if (holdPlaceData.endedAt != null) {
-		throw new fw.types.BadRequest("HoldPlace is already ended");
-	}
-	const playInfo = normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData);
-	if (!playInfo.currentPlayId) {
-		throw new fw.types.BadRequest("Play is not started");
-	}
-	const playSnap = await firestore.collection("plays").doc(playInfo.currentPlayId).get();
-	if (!playSnap.exists) {
-		throw new fw.types.InternalServerError(`Play with id ${playInfo.currentPlayId} not found`);
-	}
-	return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData, playSnap.data() as Partial<Play>);
 }
 
 export function clearHoldPlacePlay(

--- a/functions/src/stores/index.ts
+++ b/functions/src/stores/index.ts
@@ -51,20 +51,6 @@ function resolveHoldExpireAt(behaviours: PlaceBehaviour[], now: Timestamp) {
 	return Timestamp.fromMillis(now.toMillis() + time);
 }
 
-function readOptionalString(docName: string, fieldName: string, value: unknown) {
-	if (value === undefined) return undefined;
-	if (typeof value === "string") return value;
-	throw new fw.types.InternalServerError(`${docName}.${fieldName} must be a string`);
-}
-
-function readHoldPlaceHoldUserId(holdPlaceId: string, holdPlaceData: Partial<HoldPlace>) {
-	return readOptionalString(`HoldPlace ${holdPlaceId}`, "holdUserId", holdPlaceData.holdUserId);
-}
-
-function readHoldPlaceCurrentPlayId(holdPlaceId: string, holdPlaceData: Partial<HoldPlace>) {
-	return readOptionalString(`HoldPlace ${holdPlaceId}`, "currentPlayId", holdPlaceData.currentPlayId);
-}
-
 async function endHoldPlaceTransaction(
 	firestore: Firestore,
 	transaction: Transaction,
@@ -92,7 +78,7 @@ async function endHoldPlaceTransaction(
 		throw new fw.types.Duplicate("HoldPlace is already ended");
 	}
 
-	const holdUserId = readHoldPlaceHoldUserId(holdPlaceRef.id, holdPlaceData);
+	const holdUserId = holdPlaceData.holdUserId;
 	if (input.requireOwner && holdUserId && holdUserId !== input.holdUserId) {
 		throw new fw.types.Forbidden("HoldPlace is owned by another user");
 	}
@@ -104,7 +90,7 @@ async function endHoldPlaceTransaction(
 
 	const now = input.now ?? Timestamp.now();
 	const placeId = input.placeId ?? holdPlaceData.placeId;
-	const currentPlayId = readHoldPlaceCurrentPlayId(holdPlaceRef.id, holdPlaceData);
+	const currentPlayId = holdPlaceData.currentPlayId;
 	const playRef = currentPlayId ? firestore.collection("plays").doc(currentPlayId) : undefined;
 	const playSnap = playRef ? await transaction.get(playRef) : undefined;
 	if (placeId != undefined) {
@@ -159,8 +145,8 @@ function normalizeHoldPlacePlayInfo(
 	return {
 		holdPlaceId,
 		placeId: readHoldPlacePlaceId(holdPlaceId, holdPlaceData),
-		holdUserId: readHoldPlaceHoldUserId(holdPlaceId, holdPlaceData),
-		currentPlayId: readHoldPlaceCurrentPlayId(holdPlaceId, holdPlaceData),
+		holdUserId: holdPlaceData.holdUserId,
+		currentPlayId: holdPlaceData.currentPlayId,
 		providerId: playData?.providerId,
 		contentCode: playData?.contentCode,
 		contentUrl: playData?.contentUrl,
@@ -231,8 +217,7 @@ export function holdPlace(
 		}
 
 		const placeData = placeSnap.data() as Partial<Place>;
-		const currentHoldPlaceId =
-			typeof placeData.currentHoldPlaceId === "string" ? placeData.currentHoldPlaceId : undefined;
+		const currentHoldPlaceId = placeData.currentHoldPlaceId;
 		if (currentHoldPlaceId) {
 			throw new fw.types.Duplicate("Place is already held");
 		}
@@ -277,8 +262,7 @@ export function releaseHoldPlace(
 		}
 
 		const placeData = placeSnap.data() as Partial<Place>;
-		const currentHoldPlaceId =
-			typeof placeData.currentHoldPlaceId === "string" ? placeData.currentHoldPlaceId : undefined;
+		const currentHoldPlaceId = placeData.currentHoldPlaceId;
 		if (!currentHoldPlaceId) {
 			throw new fw.types.BadRequest("Place is not held");
 		}
@@ -326,8 +310,7 @@ export async function getCurrentHoldPlacePlayInfo(
 	}
 
 	const placeData = placeSnap.data() as Partial<Place>;
-	const currentHoldPlaceId =
-		typeof placeData.currentHoldPlaceId === "string" ? placeData.currentHoldPlaceId : undefined;
+	const currentHoldPlaceId = placeData.currentHoldPlaceId;
 	if (!currentHoldPlaceId) {
 		throw new fw.types.BadRequest("Place is not held");
 	}
@@ -341,12 +324,12 @@ export async function getCurrentHoldPlacePlayInfo(
 	if (holdPlaceData.endedAt != null) {
 		throw new fw.types.BadRequest("HoldPlace is already ended");
 	}
-	const holdUserId = readHoldPlaceHoldUserId(holdPlaceSnap.id, holdPlaceData);
+	const holdUserId = holdPlaceData.holdUserId;
 	if (input.requireOwner && holdUserId && holdUserId !== input.holdUserId) {
 		throw new fw.types.Forbidden("HoldPlace is owned by another user");
 	}
 
-	const currentPlayId = readHoldPlaceCurrentPlayId(holdPlaceSnap.id, holdPlaceData);
+	const currentPlayId = holdPlaceData.currentPlayId;
 	if (!currentPlayId) {
 		return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData);
 	}
@@ -380,11 +363,11 @@ export function setHoldPlacePlay(
 		if (holdPlaceData.endedAt != null) {
 			throw new fw.types.BadRequest("HoldPlace is already ended");
 		}
-		const holdUserId = readHoldPlaceHoldUserId(holdPlaceRef.id, holdPlaceData);
+		const holdUserId = holdPlaceData.holdUserId;
 		if (holdUserId && holdUserId !== input.holdUserId) {
 			throw new fw.types.Forbidden("HoldPlace is owned by another user");
 		}
-		const currentPlayId = readHoldPlaceCurrentPlayId(holdPlaceRef.id, holdPlaceData);
+		const currentPlayId = holdPlaceData.currentPlayId;
 		if (currentPlayId) {
 			const playSnap = await transaction.get(firestore.collection("plays").doc(currentPlayId));
 			if (!playSnap.exists) {
@@ -469,12 +452,12 @@ export function clearHoldPlacePlay(
 		}
 
 		const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
-		const holdUserId = readHoldPlaceHoldUserId(holdPlaceRef.id, holdPlaceData);
+		const holdUserId = holdPlaceData.holdUserId;
 		if (input.requireOwner && holdUserId && holdUserId !== input.holdUserId) {
 			throw new fw.types.Forbidden("HoldPlace is owned by another user");
 		}
 
-		const currentPlayId = readHoldPlaceCurrentPlayId(holdPlaceRef.id, holdPlaceData);
+		const currentPlayId = holdPlaceData.currentPlayId;
 		const playRef = currentPlayId ? firestore.collection("plays").doc(currentPlayId) : undefined;
 		const playSnap = playRef ? await transaction.get(playRef) : undefined;
 		const playInfo = normalizeHoldPlacePlayInfo(

--- a/functions/src/stores/index.ts
+++ b/functions/src/stores/index.ts
@@ -51,6 +51,20 @@ function resolveHoldExpireAt(behaviours: PlaceBehaviour[], now: Timestamp) {
 	return Timestamp.fromMillis(now.toMillis() + time);
 }
 
+function readOptionalString(docName: string, fieldName: string, value: unknown) {
+	if (value === undefined) return undefined;
+	if (typeof value === "string") return value;
+	throw new fw.types.InternalServerError(`${docName}.${fieldName} must be a string`);
+}
+
+function readHoldPlaceHoldUserId(holdPlaceId: string, holdPlaceData: Partial<HoldPlace>) {
+	return readOptionalString(`HoldPlace ${holdPlaceId}`, "holdUserId", holdPlaceData.holdUserId);
+}
+
+function readHoldPlaceCurrentPlayId(holdPlaceId: string, holdPlaceData: Partial<HoldPlace>) {
+	return readOptionalString(`HoldPlace ${holdPlaceId}`, "currentPlayId", holdPlaceData.currentPlayId);
+}
+
 async function endHoldPlaceTransaction(
 	firestore: Firestore,
 	transaction: Transaction,
@@ -78,7 +92,8 @@ async function endHoldPlaceTransaction(
 		throw new fw.types.Duplicate("HoldPlace is already ended");
 	}
 
-	if (input.requireOwner && holdPlaceData.holdUserId && holdPlaceData.holdUserId !== input.holdUserId) {
+	const holdUserId = readHoldPlaceHoldUserId(holdPlaceRef.id, holdPlaceData);
+	if (input.requireOwner && holdUserId && holdUserId !== input.holdUserId) {
 		throw new fw.types.Forbidden("HoldPlace is owned by another user");
 	}
 
@@ -89,7 +104,7 @@ async function endHoldPlaceTransaction(
 
 	const now = input.now ?? Timestamp.now();
 	const placeId = input.placeId ?? holdPlaceData.placeId;
-	const currentPlayId = typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
+	const currentPlayId = readHoldPlaceCurrentPlayId(holdPlaceRef.id, holdPlaceData);
 	const playRef = currentPlayId ? firestore.collection("plays").doc(currentPlayId) : undefined;
 	const playSnap = playRef ? await transaction.get(playRef) : undefined;
 	if (placeId != undefined) {
@@ -144,8 +159,8 @@ function normalizeHoldPlacePlayInfo(
 	return {
 		holdPlaceId,
 		placeId: readHoldPlacePlaceId(holdPlaceId, holdPlaceData),
-		holdUserId: typeof holdPlaceData.holdUserId === "string" ? holdPlaceData.holdUserId : undefined,
-		currentPlayId: typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined,
+		holdUserId: readHoldPlaceHoldUserId(holdPlaceId, holdPlaceData),
+		currentPlayId: readHoldPlaceCurrentPlayId(holdPlaceId, holdPlaceData),
 		providerId: playData?.providerId,
 		contentCode: playData?.contentCode,
 		contentUrl: playData?.contentUrl,
@@ -326,11 +341,12 @@ export async function getCurrentHoldPlacePlayInfo(
 	if (holdPlaceData.endedAt != null) {
 		throw new fw.types.BadRequest("HoldPlace is already ended");
 	}
-	if (input.requireOwner && holdPlaceData.holdUserId && holdPlaceData.holdUserId !== input.holdUserId) {
+	const holdUserId = readHoldPlaceHoldUserId(holdPlaceSnap.id, holdPlaceData);
+	if (input.requireOwner && holdUserId && holdUserId !== input.holdUserId) {
 		throw new fw.types.Forbidden("HoldPlace is owned by another user");
 	}
 
-	const currentPlayId = typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
+	const currentPlayId = readHoldPlaceCurrentPlayId(holdPlaceSnap.id, holdPlaceData);
 	if (!currentPlayId) {
 		return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData);
 	}
@@ -364,11 +380,11 @@ export function setHoldPlacePlay(
 		if (holdPlaceData.endedAt != null) {
 			throw new fw.types.BadRequest("HoldPlace is already ended");
 		}
-		if (holdPlaceData.holdUserId && holdPlaceData.holdUserId !== input.holdUserId) {
+		const holdUserId = readHoldPlaceHoldUserId(holdPlaceRef.id, holdPlaceData);
+		if (holdUserId && holdUserId !== input.holdUserId) {
 			throw new fw.types.Forbidden("HoldPlace is owned by another user");
 		}
-		const currentPlayId =
-			typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
+		const currentPlayId = readHoldPlaceCurrentPlayId(holdPlaceRef.id, holdPlaceData);
 		if (currentPlayId) {
 			const playSnap = await transaction.get(firestore.collection("plays").doc(currentPlayId));
 			if (!playSnap.exists) {
@@ -453,12 +469,12 @@ export function clearHoldPlacePlay(
 		}
 
 		const holdPlaceData = holdPlaceSnap.data() as Partial<HoldPlace>;
-		if (input.requireOwner && holdPlaceData.holdUserId && holdPlaceData.holdUserId !== input.holdUserId) {
+		const holdUserId = readHoldPlaceHoldUserId(holdPlaceRef.id, holdPlaceData);
+		if (input.requireOwner && holdUserId && holdUserId !== input.holdUserId) {
 			throw new fw.types.Forbidden("HoldPlace is owned by another user");
 		}
 
-		const currentPlayId =
-			typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
+		const currentPlayId = readHoldPlaceCurrentPlayId(holdPlaceRef.id, holdPlaceData);
 		const playRef = currentPlayId ? firestore.collection("plays").doc(currentPlayId) : undefined;
 		const playSnap = playRef ? await transaction.get(playRef) : undefined;
 		const playInfo = normalizeHoldPlacePlayInfo(

--- a/functions/src/stores/index.ts
+++ b/functions/src/stores/index.ts
@@ -23,11 +23,9 @@ export interface HoldPlacePlayInfo {
 	placeId: string;
 	holdUserId?: string;
 	currentPlayId?: string;
-	gameCode?: string;
-	gameTitle?: string;
-	gameDescription?: string;
+	providerId?: string;
+	contentCode?: string;
 	contentUrl?: string;
-	inputAdapter?: string;
 	ownerUserId?: string;
 	expireAt?: Timestamp;
 }
@@ -148,12 +146,10 @@ function normalizeHoldPlacePlayInfo(
 		placeId: readHoldPlacePlaceId(holdPlaceId, holdPlaceData),
 		holdUserId: typeof holdPlaceData.holdUserId === "string" ? holdPlaceData.holdUserId : undefined,
 		currentPlayId: typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined,
-		gameCode: typeof playData?.gameCode === "string" ? playData.gameCode : undefined,
-		gameTitle: typeof playData?.title === "string" ? playData.title : undefined,
-		gameDescription: typeof playData?.description === "string" ? playData.description : undefined,
-		contentUrl: typeof playData?.contentUrl === "string" ? playData.contentUrl : undefined,
-		inputAdapter: typeof playData?.inputAdapter === "string" ? playData.inputAdapter : undefined,
-		ownerUserId: typeof playData?.ownerUserId === "string" ? playData.ownerUserId : undefined,
+		providerId: playData?.providerId,
+		contentCode: playData?.contentCode,
+		contentUrl: playData?.contentUrl,
+		ownerUserId: playData?.ownerUserId,
 		expireAt: holdPlaceData.expireAt,
 	};
 }
@@ -353,11 +349,7 @@ export function setHoldPlacePlay(
 		systemPlayId: string;
 		providerId: string;
 		contentCode: string;
-		gameCode: string;
-		gameTitle: string;
-		gameDescription: string;
 		contentUrl: string;
-		inputAdapter: string;
 		ownerUserId: string;
 	},
 ) {
@@ -375,7 +367,8 @@ export function setHoldPlacePlay(
 		if (holdPlaceData.holdUserId && holdPlaceData.holdUserId !== input.holdUserId) {
 			throw new fw.types.Forbidden("HoldPlace is owned by another user");
 		}
-		const currentPlayId = typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
+		const currentPlayId =
+			typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
 		if (currentPlayId) {
 			const playSnap = await transaction.get(firestore.collection("plays").doc(currentPlayId));
 			if (!playSnap.exists) {
@@ -392,10 +385,6 @@ export function setHoldPlacePlay(
 			providerId: input.providerId,
 			contentCode: input.contentCode,
 			contentUrl: input.contentUrl,
-			gameCode: input.gameCode,
-			title: input.gameTitle,
-			description: input.gameDescription,
-			inputAdapter: input.inputAdapter,
 			state: "playing",
 			ownerUserId: input.ownerUserId,
 			joinedPlayerIds: [],
@@ -411,10 +400,14 @@ export function setHoldPlacePlay(
 		await transaction.set(firestore.collection("plays").doc(input.systemPlayId), eraseUndefined(play));
 		await transaction.update(holdPlaceRef, nextHoldPlaceData);
 
-		return normalizeHoldPlacePlayInfo(holdPlaceRef.id, {
-			...holdPlaceData,
-			...nextHoldPlaceData,
-		}, play);
+		return normalizeHoldPlacePlayInfo(
+			holdPlaceRef.id,
+			{
+				...holdPlaceData,
+				...nextHoldPlaceData,
+			},
+			play,
+		);
 	});
 }
 
@@ -464,7 +457,8 @@ export function clearHoldPlacePlay(
 			throw new fw.types.Forbidden("HoldPlace is owned by another user");
 		}
 
-		const currentPlayId = typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
+		const currentPlayId =
+			typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
 		const playRef = currentPlayId ? firestore.collection("plays").doc(currentPlayId) : undefined;
 		const playSnap = playRef ? await transaction.get(playRef) : undefined;
 		const playInfo = normalizeHoldPlacePlayInfo(

--- a/functions/src/stores/index.ts
+++ b/functions/src/stores/index.ts
@@ -2,7 +2,15 @@ import { UserProfile } from "../types";
 import { Firestore, Timestamp, FieldValue, Transaction } from "firebase-admin/firestore";
 import { eraseUndefined } from "../utils";
 import * as fw from "../fw";
-import { HoldPlace, Place, PlaceBehaviour, PlaceHoldableTimeBehaviour } from "../types/firestore";
+import {
+	HoldPlace,
+	Place,
+	PlaceBehaviour,
+	PlaceDefaultPermissionBehaviour,
+	PlaceHoldableTimeBehaviour,
+	Play,
+	PlayPermission,
+} from "../types/firestore";
 
 export interface EndedHoldPlaceResult {
 	holdPlaceId: string;
@@ -15,18 +23,26 @@ export interface HoldPlacePlayInfo {
 	placeId: string;
 	holdUserId?: string;
 	currentPlayId?: string;
-	currentPlayGameCode?: string;
-	currentPlayTitle?: string;
-	currentPlayDescription?: string;
-	currentPlayContentUrl?: string;
-	currentPlayInputAdapter?: string;
-	activeUserId?: string;
+	gameCode?: string;
+	gameTitle?: string;
+	gameDescription?: string;
+	contentUrl?: string;
+	inputAdapter?: string;
+	ownerUserId?: string;
 	expireAt?: Timestamp;
 }
 
 // PlaceBehaviour から holdableTime バリアントを絞り込むための型ガード
 function isPlaceHoldableTimeBehaviour(behaviour: PlaceBehaviour): behaviour is PlaceHoldableTimeBehaviour {
 	return behaviour.type === "holdableTime";
+}
+
+function isPlaceDefaultPermissionBehaviour(behaviour: PlaceBehaviour): behaviour is PlaceDefaultPermissionBehaviour {
+	return behaviour.type === "defaultPermission";
+}
+
+function resolveDefaultPermission(behaviours: PlaceBehaviour[]): PlayPermission {
+	return behaviours.find(isPlaceDefaultPermissionBehaviour)?.permission ?? "viewer";
 }
 
 function resolveHoldExpireAt(behaviours: PlaceBehaviour[], now: Timestamp) {
@@ -76,6 +92,8 @@ async function endHoldPlaceTransaction(
 	const now = input.now ?? Timestamp.now();
 	const placeId = input.placeId ?? holdPlaceData.placeId;
 	const currentPlayId = typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
+	const playRef = currentPlayId ? firestore.collection("plays").doc(currentPlayId) : undefined;
+	const playSnap = playRef ? await transaction.get(playRef) : undefined;
 	if (placeId != undefined) {
 		const placeRef = firestore.collection("places").doc(placeId);
 		const placeSnap = await transaction.get(placeRef);
@@ -88,6 +106,13 @@ async function endHoldPlaceTransaction(
 				});
 			}
 		}
+	}
+
+	if (playRef && playSnap?.exists) {
+		await transaction.update(playRef, {
+			state: "ended",
+			updatedAt: now,
+		});
 	}
 
 	await transaction.update(
@@ -106,25 +131,29 @@ async function endHoldPlaceTransaction(
 	};
 }
 
-function normalizeHoldPlacePlayInfo(holdPlaceId: string, holdPlaceData: Partial<HoldPlace>): HoldPlacePlayInfo {
+function readHoldPlacePlaceId(holdPlaceId: string, holdPlaceData: Partial<HoldPlace>) {
+	if (typeof holdPlaceData.placeId === "string" && holdPlaceData.placeId) {
+		return holdPlaceData.placeId;
+	}
+	throw new fw.types.InternalServerError(`HoldPlace ${holdPlaceId} has no placeId`);
+}
+
+function normalizeHoldPlacePlayInfo(
+	holdPlaceId: string,
+	holdPlaceData: Partial<HoldPlace>,
+	playData?: Partial<Play>,
+): HoldPlacePlayInfo {
 	return {
 		holdPlaceId,
-		placeId: holdPlaceData.placeId ?? "",
+		placeId: readHoldPlacePlaceId(holdPlaceId, holdPlaceData),
 		holdUserId: typeof holdPlaceData.holdUserId === "string" ? holdPlaceData.holdUserId : undefined,
 		currentPlayId: typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined,
-		currentPlayGameCode:
-			typeof holdPlaceData.currentPlayGameCode === "string" ? holdPlaceData.currentPlayGameCode : undefined,
-		currentPlayTitle:
-			typeof holdPlaceData.currentPlayTitle === "string" ? holdPlaceData.currentPlayTitle : undefined,
-		currentPlayDescription:
-			typeof holdPlaceData.currentPlayDescription === "string"
-				? holdPlaceData.currentPlayDescription
-				: undefined,
-		currentPlayContentUrl:
-			typeof holdPlaceData.currentPlayContentUrl === "string" ? holdPlaceData.currentPlayContentUrl : undefined,
-		currentPlayInputAdapter:
-			typeof holdPlaceData.currentPlayInputAdapter === "string" ? holdPlaceData.currentPlayInputAdapter : undefined,
-		activeUserId: typeof holdPlaceData.activeUserId === "string" ? holdPlaceData.activeUserId : undefined,
+		gameCode: typeof playData?.gameCode === "string" ? playData.gameCode : undefined,
+		gameTitle: typeof playData?.title === "string" ? playData.title : undefined,
+		gameDescription: typeof playData?.description === "string" ? playData.description : undefined,
+		contentUrl: typeof playData?.contentUrl === "string" ? playData.contentUrl : undefined,
+		inputAdapter: typeof playData?.inputAdapter === "string" ? playData.inputAdapter : undefined,
+		ownerUserId: typeof playData?.ownerUserId === "string" ? playData.ownerUserId : undefined,
 		expireAt: holdPlaceData.expireAt,
 	};
 }
@@ -305,7 +334,15 @@ export async function getCurrentHoldPlacePlayInfo(
 		throw new fw.types.Forbidden("HoldPlace is owned by another user");
 	}
 
-	return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData);
+	const currentPlayId = typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
+	if (!currentPlayId) {
+		return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData);
+	}
+	const playSnap = await firestore.collection("plays").doc(currentPlayId).get();
+	if (!playSnap.exists) {
+		throw new fw.types.InternalServerError(`Play with id ${currentPlayId} not found`);
+	}
+	return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData, playSnap.data() as Partial<Play>);
 }
 
 export function setHoldPlacePlay(
@@ -314,12 +351,14 @@ export function setHoldPlacePlay(
 		holdPlaceId: string;
 		holdUserId?: string;
 		systemPlayId: string;
+		providerId: string;
+		contentCode: string;
 		gameCode: string;
 		gameTitle: string;
 		gameDescription: string;
 		contentUrl: string;
 		inputAdapter: string;
-		activeUserId: string;
+		ownerUserId: string;
 	},
 ) {
 	return firestore.runTransaction(async (transaction) => {
@@ -336,27 +375,46 @@ export function setHoldPlacePlay(
 		if (holdPlaceData.holdUserId && holdPlaceData.holdUserId !== input.holdUserId) {
 			throw new fw.types.Forbidden("HoldPlace is owned by another user");
 		}
-		if (typeof holdPlaceData.currentPlayId === "string") {
-			return normalizeHoldPlacePlayInfo(holdPlaceRef.id, holdPlaceData);
+		const currentPlayId = typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
+		if (currentPlayId) {
+			const playSnap = await transaction.get(firestore.collection("plays").doc(currentPlayId));
+			if (!playSnap.exists) {
+				throw new fw.types.InternalServerError(`Play with id ${currentPlayId} not found`);
+			}
+			return normalizeHoldPlacePlayInfo(holdPlaceRef.id, holdPlaceData, playSnap.data() as Partial<Play>);
 		}
 
 		const now = Timestamp.now();
-		const nextData = {
-			currentPlayId: input.systemPlayId,
-			currentPlayGameCode: input.gameCode,
-			currentPlayTitle: input.gameTitle,
-			currentPlayDescription: input.gameDescription,
-			currentPlayContentUrl: input.contentUrl,
-			currentPlayInputAdapter: input.inputAdapter,
-			activeUserId: input.activeUserId,
+		const behaviours = Array.isArray(holdPlaceData.behaviours) ? holdPlaceData.behaviours : [];
+		const play: Play = {
+			placeId: readHoldPlacePlaceId(holdPlaceRef.id, holdPlaceData),
+			holdPlaceId: holdPlaceRef.id,
+			providerId: input.providerId,
+			contentCode: input.contentCode,
+			contentUrl: input.contentUrl,
+			gameCode: input.gameCode,
+			title: input.gameTitle,
+			description: input.gameDescription,
+			inputAdapter: input.inputAdapter,
+			state: "playing",
+			ownerUserId: input.ownerUserId,
+			joinedPlayerIds: [],
+			defaultPermission: resolveDefaultPermission(behaviours),
+			expireAt: holdPlaceData.expireAt,
+			createdAt: now,
 			updatedAt: now,
 		};
-		await transaction.update(holdPlaceRef, nextData);
+		const nextHoldPlaceData = {
+			currentPlayId: input.systemPlayId,
+			updatedAt: now,
+		};
+		await transaction.set(firestore.collection("plays").doc(input.systemPlayId), eraseUndefined(play));
+		await transaction.update(holdPlaceRef, nextHoldPlaceData);
 
 		return normalizeHoldPlacePlayInfo(holdPlaceRef.id, {
 			...holdPlaceData,
-			...nextData,
-		});
+			...nextHoldPlaceData,
+		}, play);
 	});
 }
 
@@ -379,7 +437,11 @@ export async function getHoldPlacePlayInfo(
 	if (!playInfo.currentPlayId) {
 		throw new fw.types.BadRequest("Play is not started");
 	}
-	return playInfo;
+	const playSnap = await firestore.collection("plays").doc(playInfo.currentPlayId).get();
+	if (!playSnap.exists) {
+		throw new fw.types.InternalServerError(`Play with id ${playInfo.currentPlayId} not found`);
+	}
+	return normalizeHoldPlacePlayInfo(holdPlaceSnap.id, holdPlaceData, playSnap.data() as Partial<Play>);
 }
 
 export function clearHoldPlacePlay(
@@ -402,15 +464,22 @@ export function clearHoldPlacePlay(
 			throw new fw.types.Forbidden("HoldPlace is owned by another user");
 		}
 
-		const playInfo = normalizeHoldPlacePlayInfo(holdPlaceRef.id, holdPlaceData);
+		const currentPlayId = typeof holdPlaceData.currentPlayId === "string" ? holdPlaceData.currentPlayId : undefined;
+		const playRef = currentPlayId ? firestore.collection("plays").doc(currentPlayId) : undefined;
+		const playSnap = playRef ? await transaction.get(playRef) : undefined;
+		const playInfo = normalizeHoldPlacePlayInfo(
+			holdPlaceRef.id,
+			holdPlaceData,
+			playSnap?.exists ? (playSnap.data() as Partial<Play>) : undefined,
+		);
+		if (playRef && playSnap?.exists) {
+			await transaction.update(playRef, {
+				state: "ended",
+				updatedAt: Timestamp.now(),
+			});
+		}
 		await transaction.update(holdPlaceRef, {
 			currentPlayId: FieldValue.delete(),
-			currentPlayGameCode: FieldValue.delete(),
-			currentPlayTitle: FieldValue.delete(),
-			currentPlayDescription: FieldValue.delete(),
-			currentPlayContentUrl: FieldValue.delete(),
-			currentPlayInputAdapter: FieldValue.delete(),
-			activeUserId: FieldValue.delete(),
 			updatedAt: Timestamp.now(),
 		});
 		return playInfo;

--- a/functions/src/types/firestore.ts
+++ b/functions/src/types/firestore.ts
@@ -139,14 +139,6 @@ export interface Play {
 	 */
 	contentUrl: string;
 
-	gameCode?: string;
-
-	title?: string;
-
-	description?: string;
-
-	inputAdapter?: string;
-
 	/**
 	 * プレイの状態。
 	 */

--- a/functions/src/types/firestore.ts
+++ b/functions/src/types/firestore.ts
@@ -90,18 +90,6 @@ export interface HoldPlace {
 	 */
 	currentPlayId?: string;
 
-	currentPlayGameCode?: string;
-
-	currentPlayTitle?: string;
-
-	currentPlayDescription?: string;
-
-	currentPlayContentUrl?: string;
-
-	currentPlayInputAdapter?: string;
-
-	activeUserId?: string;
-
 	/**
 	 * HoldPlaceの有効期限。
 	 * Timestamp型だが、分が最小単位であることが保証される。
@@ -150,6 +138,14 @@ export interface Play {
 	 * 同一のproviderId、同一のcontentCodeでも、バージョン等が違えば異なる事がある。
 	 */
 	contentUrl: string;
+
+	gameCode?: string;
+
+	title?: string;
+
+	description?: string;
+
+	inputAdapter?: string;
 
 	/**
 	 * プレイの状態。

--- a/functions/src/types/firestore.ts
+++ b/functions/src/types/firestore.ts
@@ -90,6 +90,18 @@ export interface HoldPlace {
 	 */
 	currentPlayId?: string;
 
+	currentPlayGameCode?: string;
+
+	currentPlayTitle?: string;
+
+	currentPlayDescription?: string;
+
+	currentPlayContentUrl?: string;
+
+	currentPlayInputAdapter?: string;
+
+	activeUserId?: string;
+
 	/**
 	 * HoldPlaceの有効期限。
 	 * Timestamp型だが、分が最小単位であることが保証される。

--- a/src/App.ts
+++ b/src/App.ts
@@ -201,7 +201,13 @@ export class App {
 		});
 		window.addEventListener("message", (event) => {
 			if (event.data?.type !== "akashic-system-launch-ready") return;
-			this.postPlayLaunchConfig(event.origin);
+			const launch = this.playLaunchState.launch;
+			if (!launch) return;
+			const frame = this.rootEl.querySelector<HTMLIFrameElement>("#play-frame");
+			if (!frame?.contentWindow || event.source !== frame.contentWindow) return;
+			const expectedOrigin = new URL(launch.gamePageUrl).origin;
+			if (event.origin !== expectedOrigin) return;
+			this.postPlayLaunchConfig(expectedOrigin);
 		});
 	}
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -481,7 +481,7 @@ export class App {
 				<div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
 					<div>
 						<div class="small text-muted">${utils.escapeHtml(modeLabel)}</div>
-						<div class="fw-semibold">${utils.escapeHtml(launch.gameTitle || launch.gameCode)}</div>
+						<div class="fw-semibold">${utils.escapeHtml(launch.gameTitle || "Akashic Game")}</div>
 						<div class="small text-muted">Play ID: ${utils.escapeHtml(launch.playId)}</div>
 					</div>
 					${
@@ -514,7 +514,7 @@ export class App {
 						</div>
 						<div class="mb-3">
 							<div class="small text-muted mb-1">コンテンツ</div>
-							<div class="fw-semibold">${utils.escapeHtml(launch.gameTitle || launch.gameCode)}</div>
+							<div class="fw-semibold">${utils.escapeHtml(launch.gameTitle || "Akashic Game")}</div>
 							<div class="small text-secondary">${utils.escapeHtml(launch.gameDescription || "")}</div>
 						</div>
 						${expireText ? `<div class="small text-muted">このPlayは ${utils.escapeHtml(expireText)} まで遊べます。</div>` : ""}
@@ -618,9 +618,7 @@ export class App {
 					mode: launch.mode,
 					playId: launch.playId,
 					userId: launch.userId,
-					gameCode: launch.gameCode,
 					contentUrl: launch.contentUrl,
-					inputAdapter: launch.inputAdapter,
 					playToken: launch.playToken,
 					playlogServerUrl: launch.playlogServerUrl,
 				},

--- a/src/App.ts
+++ b/src/App.ts
@@ -517,11 +517,7 @@ export class App {
 							<div class="fw-semibold">${utils.escapeHtml(launch.gameTitle || launch.gameCode)}</div>
 							<div class="small text-secondary">${utils.escapeHtml(launch.gameDescription || "")}</div>
 						</div>
-						${
-							expireText
-								? `<div class="small text-muted">このPlayは ${utils.escapeHtml(expireText)} まで遊べます。</div>`
-								: ""
-						}
+						${expireText ? `<div class="small text-muted">このPlayは ${utils.escapeHtml(expireText)} まで遊べます。</div>` : ""}
 					</div>
 				</div>
 			`;
@@ -904,12 +900,16 @@ export class App {
 			const holdButtonLabel = isHoldSubmitting ? "確保中" : "確保する";
 			const releaseButtonLabel = isReleaseSubmitting ? "解放中" : "解放する";
 			const playStarting =
-				!!holdPlace && this.placeState.playStarting && this.placeState.playStartingHoldPlaceId === holdPlace.id;
+				!!holdPlace &&
+				this.placeState.playStarting &&
+				this.placeState.playStartingHoldPlaceId === holdPlace.id;
 			const playEnding =
 				!!holdPlace && this.placeState.playEnding && this.placeState.playEndingHoldPlaceId === holdPlace.id;
-			const joinUrl = holdPlace ? new URL(`/play/${encodeURIComponent(holdPlace.id)}`, location.origin).toString() : "";
-			const currentGameTitle = holdPlace?.currentPlayTitle || holdPlace?.currentPlayGameCode || fixedGameTitle;
-			const currentGameDescription = holdPlace?.currentPlayDescription || fixedGameDescription;
+			const joinUrl = holdPlace
+				? new URL(`/play/${encodeURIComponent(holdPlace.id)}`, location.origin).toString()
+				: "";
+			const currentGameTitle = fixedGameTitle;
+			const currentGameDescription = fixedGameDescription;
 			const currentGameDescriptionMarkup = currentGameDescription
 				? `<div class="small text-secondary mb-2">${utils.escapeHtml(currentGameDescription)}</div>`
 				: "";
@@ -1672,8 +1672,13 @@ export class App {
 			copyPlayButton.addEventListener("click", async () => {
 				const url = copyPlayButton.dataset.url;
 				if (!url) return;
-				await navigator.clipboard.writeText(url);
-				this.showToast("URLをコピーしました。", "success");
+				try {
+					await navigator.clipboard.writeText(url);
+					this.showToast("URLをコピーしました。", "success");
+				} catch (err) {
+					console.error(err);
+					this.showToast("URLのコピーに失敗しました。", "error");
+				}
 			});
 		}
 
@@ -1708,8 +1713,13 @@ export class App {
 			copyUrlButton.addEventListener("click", async () => {
 				const url = copyUrlButton.dataset.url;
 				if (!url) return;
-				await navigator.clipboard.writeText(url);
-				this.showToast("URLをコピーしました。", "success");
+				try {
+					await navigator.clipboard.writeText(url);
+					this.showToast("URLをコピーしました。", "success");
+				} catch (err) {
+					console.error(err);
+					this.showToast("URLのコピーに失敗しました。", "error");
+				}
 			});
 		}
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -2,7 +2,14 @@ import { connectAuthEmulator, type User as FirebaseUser } from "firebase/auth";
 import { connectFirestoreEmulator } from "firebase/firestore";
 import { signInWithGoogle, signOutCurrentUser, watchAuthChanges } from "./auth";
 import { Client as ApiClient } from "./api/client";
-import { holdPlace, releasePlace } from "./api/places";
+import {
+	endHoldPlacePlay,
+	holdPlace,
+	launchHoldPlacePlay,
+	type LaunchHoldPlacePlayResult,
+	releasePlace,
+	startPlacePlay,
+} from "./api/places";
 import { createUser, updateUser } from "./api/users";
 import { appConfig } from "./config";
 import type { AppConfig } from "./config.types";
@@ -24,6 +31,9 @@ type AuthState = {
 };
 
 type PlaceStatus = "playing" | "idle";
+
+const fixedGameTitle = "Rocket Game";
+const fixedGameDescription = "";
 
 type TopState = {
 	places: Place[];
@@ -56,6 +66,19 @@ type PlaceState = {
 	holdSubmittingPlaceId: string | null;
 	releaseSubmitting: boolean;
 	releaseSubmittingPlaceId: string | null;
+	playStarting: boolean;
+	playStartingHoldPlaceId: string | null;
+	playEnding: boolean;
+	playEndingHoldPlaceId: string | null;
+};
+
+type PlayLaunchState = {
+	holdPlaceId: string | null;
+	loading: boolean;
+	loaded: boolean;
+	error: string | null;
+	launch: LaunchHoldPlacePlayResult | null;
+	ending: boolean;
 };
 
 export class App {
@@ -67,6 +90,7 @@ export class App {
 	state: AuthState;
 	topState: TopState;
 	placeState: PlaceState;
+	playLaunchState: PlayLaunchState;
 	placeWatchUnsub: (() => void) | null;
 	placeWatchId: string | null;
 	holdPlaceWatchUnsub: (() => void) | null;
@@ -124,6 +148,19 @@ export class App {
 			holdSubmittingPlaceId: null,
 			releaseSubmitting: false,
 			releaseSubmittingPlaceId: null,
+			playStarting: false,
+			playStartingHoldPlaceId: null,
+			playEnding: false,
+			playEndingHoldPlaceId: null,
+		};
+
+		this.playLaunchState = {
+			holdPlaceId: null,
+			loading: false,
+			loaded: false,
+			error: null,
+			launch: null,
+			ending: false,
 		};
 
 		this.placeWatchUnsub = null;
@@ -161,6 +198,10 @@ export class App {
 			if (utils.parseRoute().name !== "top") return;
 			const gridMetrics = this.getGridMetrics(this.topState.places);
 			this.applyTopGridLayout(gridMetrics);
+		});
+		window.addEventListener("message", (event) => {
+			if (event.data?.type !== "akashic-system-launch-ready") return;
+			this.postPlayLaunchConfig(event.origin);
 		});
 	}
 
@@ -206,7 +247,11 @@ export class App {
 				this.placeState.holdSubmitting ||
 				this.placeState.holdSubmittingPlaceId ||
 				this.placeState.releaseSubmitting ||
-				this.placeState.releaseSubmittingPlaceId
+				this.placeState.releaseSubmittingPlaceId ||
+				this.placeState.playStarting ||
+				this.placeState.playStartingHoldPlaceId ||
+				this.placeState.playEnding ||
+				this.placeState.playEndingHoldPlaceId
 			) {
 				this.placeState = {
 					...this.placeState,
@@ -222,8 +267,22 @@ export class App {
 					holdSubmittingPlaceId: null,
 					releaseSubmitting: false,
 					releaseSubmittingPlaceId: null,
+					playStarting: false,
+					playStartingHoldPlaceId: null,
+					playEnding: false,
+					playEndingHoldPlaceId: null,
 				};
 			}
+		}
+		if (route.name !== "play" && this.playLaunchState.holdPlaceId) {
+			this.playLaunchState = {
+				holdPlaceId: null,
+				loading: false,
+				loaded: false,
+				error: null,
+				launch: null,
+				ending: false,
+			};
 		}
 		switch (route.name) {
 			case "login":
@@ -240,6 +299,9 @@ export class App {
 				break;
 			case "place":
 				this.renderPlace(route.placeId);
+				break;
+			case "play":
+				this.renderPlay(route.holdPlaceId);
 				break;
 			default:
 				this.renderTop();
@@ -371,6 +433,204 @@ export class App {
 
 		this.bindMenuEvents(user);
 		this.bindPlaceEvents();
+	}
+
+	renderPlay(holdPlaceId: string) {
+		const user = this.state.user;
+		if (!user) {
+			utils.navigateTo("/login");
+			return;
+		}
+		if (user && !this.state.profileLoaded && !this.state.profileLoading) {
+			void this.loadUserProfile();
+		}
+		if (!this.state.profileLoaded || this.state.profileLoading) {
+			this.rootEl.innerHTML = '<div class="loading">Loading profile...</div>';
+			return;
+		}
+
+		if (this.playLaunchState.holdPlaceId !== holdPlaceId) {
+			this.playLaunchState = {
+				holdPlaceId,
+				loading: false,
+				loaded: false,
+				error: null,
+				launch: null,
+				ending: false,
+			};
+		}
+		if (!this.playLaunchState.loaded && !this.playLaunchState.loading) {
+			void this.loadPlayLaunch(holdPlaceId);
+		}
+
+		const menuMarkup = this.renderMenuMarkup(user, this.state.profile);
+		const { loading, error, launch, ending } = this.playLaunchState;
+		let bodyMarkup = "";
+		if (loading) {
+			bodyMarkup = '<div class="text-muted">ゲーム起動情報を取得中...</div>';
+		} else if (error) {
+			bodyMarkup = `<div class="text-danger small">${utils.escapeHtml(error)}</div>`;
+		} else if (!launch) {
+			bodyMarkup = '<div class="text-muted">起動できるPlayがありません。</div>';
+		} else {
+			const frameUrl = this.buildAkashicFrameUrl(launch);
+			const shareUrl = new URL(`/play/${encodeURIComponent(holdPlaceId)}`, location.origin).toString();
+			const expireText = this.formatDateTime(launch.expireAt);
+			const modeLabel = launch.mode === "active" ? "操作担当" : "参加中";
+			bodyMarkup = `
+				<div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+					<div>
+						<div class="small text-muted">${utils.escapeHtml(modeLabel)}</div>
+						<div class="fw-semibold">${utils.escapeHtml(launch.gameTitle || launch.gameCode)}</div>
+						<div class="small text-muted">Play ID: ${utils.escapeHtml(launch.playId)}</div>
+					</div>
+					${
+						launch.mode === "active"
+							? `<button id="play-end-button" class="btn btn-outline-secondary btn-sm" data-hold-place-id="${utils.escapeHtml(
+									holdPlaceId,
+								)}" ${ending ? "disabled" : ""} type="button">${ending ? "終了中..." : "Play終了"}</button>`
+							: ""
+					}
+				</div>
+				<div class="row g-3 align-items-start">
+					<div class="col-12 col-lg-8">
+						<div class="ratio ratio-1x1 border rounded-3 overflow-hidden bg-dark">
+							<iframe
+								id="play-frame"
+								title="Akashic Game"
+								src="${utils.escapeHtml(frameUrl)}"
+								allow="fullscreen"
+								style="border:0;"
+							></iframe>
+						</div>
+					</div>
+					<div class="col-12 col-lg-4">
+						<div class="mb-3">
+							<div class="small text-muted mb-1">参加URL</div>
+							<div class="small text-break border rounded p-2 bg-light mb-2">${utils.escapeHtml(shareUrl)}</div>
+							<button id="play-copy-url-button" class="btn btn-outline-secondary btn-sm" data-url="${utils.escapeHtml(
+								shareUrl,
+							)}" type="button">URLをコピー</button>
+						</div>
+						<div class="mb-3">
+							<div class="small text-muted mb-1">コンテンツ</div>
+							<div class="fw-semibold">${utils.escapeHtml(launch.gameTitle || launch.gameCode)}</div>
+							<div class="small text-secondary">${utils.escapeHtml(launch.gameDescription || "")}</div>
+						</div>
+						${
+							expireText
+								? `<div class="small text-muted">このPlayは ${utils.escapeHtml(expireText)} まで遊べます。</div>`
+								: ""
+						}
+					</div>
+				</div>
+			`;
+		}
+
+		this.rootEl.innerHTML = `
+			<div class="play-page container py-5">
+				<div class="mb-3">
+					<button id="play-back" class="btn btn-outline-secondary btn-sm" ${
+						launch?.placeId ? `data-place-id="${utils.escapeHtml(launch.placeId)}"` : ""
+					} type="button">戻る</button>
+				</div>
+				<div class="card">
+					<div class="card-body">
+						${bodyMarkup}
+					</div>
+				</div>
+			</div>
+			${menuMarkup}
+		`;
+
+		this.bindMenuEvents(user);
+		this.bindPlayEvents();
+	}
+
+	buildAkashicFrameUrl(launch: LaunchHoldPlacePlayResult) {
+		const url = new URL(launch.gamePageUrl);
+		url.searchParams.set("config_source", "post_message");
+		url.searchParams.set("parent_origin", location.origin);
+		return url.toString();
+	}
+
+	formatDateTime(value: unknown) {
+		if (!value) return null;
+		let date: Date | null = null;
+		if (typeof value === "string") {
+			date = new Date(value);
+		} else if (value instanceof Date) {
+			date = value;
+		} else if (typeof (value as { toDate?: unknown }).toDate === "function") {
+			date = (value as { toDate: () => Date }).toDate();
+		}
+		if (!date || Number.isNaN(date.getTime())) return null;
+		return new Intl.DateTimeFormat("ja-JP", {
+			month: "numeric",
+			day: "numeric",
+			hour: "2-digit",
+			minute: "2-digit",
+		}).format(date);
+	}
+
+	async loadPlayLaunch(holdPlaceId: string) {
+		this.playLaunchState = {
+			holdPlaceId,
+			loading: true,
+			loaded: false,
+			error: null,
+			launch: null,
+			ending: false,
+		};
+		this.render();
+		try {
+			const response = await launchHoldPlacePlay(this.client, holdPlaceId);
+			if (this.playLaunchState.holdPlaceId !== holdPlaceId) return;
+			this.playLaunchState = {
+				holdPlaceId,
+				loading: false,
+				loaded: true,
+				error: null,
+				launch: response.data,
+				ending: false,
+			};
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "ゲーム起動情報の取得に失敗しました。";
+			if (this.playLaunchState.holdPlaceId !== holdPlaceId) return;
+			this.playLaunchState = {
+				holdPlaceId,
+				loading: false,
+				loaded: true,
+				error: message,
+				launch: null,
+				ending: false,
+			};
+		}
+		this.render();
+	}
+
+	postPlayLaunchConfig(targetOrigin?: string) {
+		const launch = this.playLaunchState.launch;
+		if (!launch) return;
+		const frame = this.rootEl.querySelector<HTMLIFrameElement>("#play-frame");
+		if (!frame?.contentWindow) return;
+		const origin = targetOrigin ?? new URL(launch.gamePageUrl).origin;
+		frame.contentWindow.postMessage(
+			{
+				type: "akashic-system-launch-config",
+				payload: {
+					mode: launch.mode,
+					playId: launch.playId,
+					userId: launch.userId,
+					gameCode: launch.gameCode,
+					contentUrl: launch.contentUrl,
+					inputAdapter: launch.inputAdapter,
+					playToken: launch.playToken,
+					playlogServerUrl: launch.playlogServerUrl,
+				},
+			},
+			origin,
+		);
 	}
 
 	getGridMetrics(places: Place[]) {
@@ -643,6 +903,62 @@ export class App {
 				this.placeState.releaseSubmitting && this.placeState.releaseSubmittingPlaceId === selectedPlace.id;
 			const holdButtonLabel = isHoldSubmitting ? "確保中" : "確保する";
 			const releaseButtonLabel = isReleaseSubmitting ? "解放中" : "解放する";
+			const playStarting =
+				!!holdPlace && this.placeState.playStarting && this.placeState.playStartingHoldPlaceId === holdPlace.id;
+			const playEnding =
+				!!holdPlace && this.placeState.playEnding && this.placeState.playEndingHoldPlaceId === holdPlace.id;
+			const joinUrl = holdPlace ? new URL(`/play/${encodeURIComponent(holdPlace.id)}`, location.origin).toString() : "";
+			const currentGameTitle = holdPlace?.currentPlayTitle || holdPlace?.currentPlayGameCode || fixedGameTitle;
+			const currentGameDescription = holdPlace?.currentPlayDescription || fixedGameDescription;
+			const currentGameDescriptionMarkup = currentGameDescription
+				? `<div class="small text-secondary mb-2">${utils.escapeHtml(currentGameDescription)}</div>`
+				: "";
+			const fixedGameDescriptionMarkup = fixedGameDescription
+				? `<div class="small text-secondary mb-2">${utils.escapeHtml(fixedGameDescription)}</div>`
+				: "";
+			const expireText = this.formatDateTime(holdPlace?.expireAt);
+			let playMarkup = "";
+			if (status === "playing" && holdPlace && !holdPlaceLoading && !holdPlaceError) {
+				if (holdPlace.currentPlayId) {
+					playMarkup = `
+						<div class="mt-3 p-3 border rounded-3 bg-light">
+							<div class="fw-semibold mb-1">${utils.escapeHtml(currentGameTitle)}</div>
+							<div class="small text-muted mb-2">Play ID: ${utils.escapeHtml(holdPlace.currentPlayId)}</div>
+							${currentGameDescriptionMarkup}
+							${expireText ? `<div class="small text-muted mb-2">このPlayは ${utils.escapeHtml(expireText)} まで遊べます。</div>` : ""}
+							<div class="small text-break mb-2">${utils.escapeHtml(joinUrl)}</div>
+							<div class="d-flex flex-wrap gap-2">
+								<button id="place-open-play-button" class="btn btn-primary btn-sm" data-url="${utils.escapeHtml(
+									joinUrl,
+								)}" type="button">ゲームを開く</button>
+								<button id="place-copy-play-button" class="btn btn-outline-secondary btn-sm" data-url="${utils.escapeHtml(
+									joinUrl,
+								)}" type="button">URLをコピー</button>
+								${
+									isSelfHolding
+										? `<button id="place-end-play-button" class="btn btn-outline-secondary btn-sm" data-hold-place-id="${utils.escapeHtml(
+												holdPlace.id,
+											)}" ${playEnding ? "disabled" : ""} type="button">${
+												playEnding ? "終了中..." : "Play終了"
+											}</button>`
+										: ""
+								}
+							</div>
+						</div>
+					`;
+				} else if (isSelfHolding) {
+					playMarkup = `
+						<div class="mt-3 p-3 border rounded-3 bg-light">
+							<div class="small text-muted mb-1">選択中のゲーム</div>
+							<div class="fw-semibold mb-1">${utils.escapeHtml(fixedGameTitle)}</div>
+							${fixedGameDescriptionMarkup}
+							<button id="place-start-play-button" class="btn btn-primary btn-sm" data-place-id="${utils.escapeHtml(
+								selectedPlace.id,
+							)}" ${playStarting ? "disabled" : ""} type="button">${playStarting ? "開始中..." : "遊ぶ"}</button>
+						</div>
+					`;
+				}
+			}
 			let ownerLabel = "";
 			if (status === "playing") {
 				if (holdPlaceLoading) {
@@ -683,6 +999,7 @@ export class App {
 							)}" ${isReleaseSubmitting ? "disabled" : ""}>${releaseButtonLabel}</button></div>`
 						: ""
 				}
+				${playMarkup}
 			`;
 		}
 
@@ -727,7 +1044,11 @@ export class App {
 				this.placeState.holdSubmitting ||
 				this.placeState.holdSubmittingPlaceId ||
 				this.placeState.releaseSubmitting ||
-				this.placeState.releaseSubmittingPlaceId
+				this.placeState.releaseSubmittingPlaceId ||
+				this.placeState.playStarting ||
+				this.placeState.playStartingHoldPlaceId ||
+				this.placeState.playEnding ||
+				this.placeState.playEndingHoldPlaceId
 			) {
 				this.placeState = {
 					...this.placeState,
@@ -743,6 +1064,10 @@ export class App {
 					holdSubmittingPlaceId: null,
 					releaseSubmitting: false,
 					releaseSubmittingPlaceId: null,
+					playStarting: false,
+					playStartingHoldPlaceId: null,
+					playEnding: false,
+					playEndingHoldPlaceId: null,
 				};
 			}
 			return;
@@ -763,6 +1088,10 @@ export class App {
 				holdSubmittingPlaceId: null,
 				releaseSubmitting: false,
 				releaseSubmittingPlaceId: null,
+				playStarting: false,
+				playStartingHoldPlaceId: null,
+				playEnding: false,
+				playEndingHoldPlaceId: null,
 			};
 		}
 
@@ -1088,6 +1417,82 @@ export class App {
 		}
 	}
 
+	async handleStartPlacePlay(placeId: string) {
+		const holdPlaceId = this.placeState.selectedHoldPlace?.id ?? null;
+		if (this.placeState.playStarting || !holdPlaceId) return;
+		this.placeState = {
+			...this.placeState,
+			playStarting: true,
+			playStartingHoldPlaceId: holdPlaceId,
+		};
+		this.render();
+		try {
+			const response = await startPlacePlay(this.client, placeId);
+			this.showToast("ゲームを開始しました。", "success");
+			const joinPath = response.data.joinPath;
+			if (joinPath) {
+				utils.navigateTo(joinPath);
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "ゲーム開始に失敗しました。";
+			this.showToast(message, "error");
+		} finally {
+			if (this.placeState.playStartingHoldPlaceId === holdPlaceId) {
+				this.placeState = {
+					...this.placeState,
+					playStarting: false,
+					playStartingHoldPlaceId: null,
+				};
+				this.render();
+			}
+		}
+	}
+
+	async handleEndHoldPlacePlay(holdPlaceId: string) {
+		if (this.placeState.playEnding || this.playLaunchState.ending) return;
+		this.placeState = {
+			...this.placeState,
+			playEnding: true,
+			playEndingHoldPlaceId: holdPlaceId,
+		};
+		this.playLaunchState = {
+			...this.playLaunchState,
+			ending: this.playLaunchState.holdPlaceId === holdPlaceId,
+		};
+		this.render();
+		try {
+			const response = await endHoldPlacePlay(this.client, holdPlaceId);
+			this.showToast("Playを終了しました。", "success");
+			if (this.playLaunchState.holdPlaceId === holdPlaceId) {
+				this.playLaunchState = {
+					...this.playLaunchState,
+					loaded: false,
+					launch: null,
+				};
+				const placeId = response.data.placeId;
+				utils.navigateTo(placeId ? `/place/${encodeURIComponent(placeId)}` : "/");
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Play終了に失敗しました。";
+			this.showToast(message, "error");
+		} finally {
+			if (this.placeState.playEndingHoldPlaceId === holdPlaceId) {
+				this.placeState = {
+					...this.placeState,
+					playEnding: false,
+					playEndingHoldPlaceId: null,
+				};
+			}
+			if (this.playLaunchState.holdPlaceId === holdPlaceId) {
+				this.playLaunchState = {
+					...this.playLaunchState,
+					ending: false,
+				};
+			}
+			this.render();
+		}
+	}
+
 	async loadPlaces() {
 		if (this.topState.loading || this.topState.loaded) return;
 		this.topState = { ...this.topState, loading: true, error: null };
@@ -1241,6 +1646,79 @@ export class App {
 				const placeId = releaseButton.dataset.placeId;
 				if (!placeId) return;
 				void this.handleReleasePlace(placeId);
+			});
+		}
+
+		const startPlayButton = this.rootEl.querySelector<HTMLButtonElement>("#place-start-play-button");
+		if (startPlayButton) {
+			startPlayButton.addEventListener("click", () => {
+				const placeId = startPlayButton.dataset.placeId;
+				if (!placeId) return;
+				void this.handleStartPlacePlay(placeId);
+			});
+		}
+
+		const openPlayButton = this.rootEl.querySelector<HTMLButtonElement>("#place-open-play-button");
+		if (openPlayButton) {
+			openPlayButton.addEventListener("click", () => {
+				const url = openPlayButton.dataset.url;
+				if (!url) return;
+				location.href = url;
+			});
+		}
+
+		const copyPlayButton = this.rootEl.querySelector<HTMLButtonElement>("#place-copy-play-button");
+		if (copyPlayButton) {
+			copyPlayButton.addEventListener("click", async () => {
+				const url = copyPlayButton.dataset.url;
+				if (!url) return;
+				await navigator.clipboard.writeText(url);
+				this.showToast("URLをコピーしました。", "success");
+			});
+		}
+
+		const endPlayButton = this.rootEl.querySelector<HTMLButtonElement>("#place-end-play-button");
+		if (endPlayButton) {
+			endPlayButton.addEventListener("click", () => {
+				const holdPlaceId = endPlayButton.dataset.holdPlaceId;
+				if (!holdPlaceId) return;
+				void this.handleEndHoldPlacePlay(holdPlaceId);
+			});
+		}
+	}
+
+	bindPlayEvents() {
+		const backButton = this.rootEl.querySelector<HTMLButtonElement>("#play-back");
+		if (backButton) {
+			backButton.addEventListener("click", () => {
+				const placeId = backButton.dataset.placeId;
+				utils.navigateTo(placeId ? `/place/${encodeURIComponent(placeId)}` : "/");
+			});
+		}
+
+		const frame = this.rootEl.querySelector<HTMLIFrameElement>("#play-frame");
+		if (frame) {
+			frame.addEventListener("load", () => {
+				window.setTimeout(() => this.postPlayLaunchConfig(), 0);
+			});
+		}
+
+		const copyUrlButton = this.rootEl.querySelector<HTMLButtonElement>("#play-copy-url-button");
+		if (copyUrlButton) {
+			copyUrlButton.addEventListener("click", async () => {
+				const url = copyUrlButton.dataset.url;
+				if (!url) return;
+				await navigator.clipboard.writeText(url);
+				this.showToast("URLをコピーしました。", "success");
+			});
+		}
+
+		const endButton = this.rootEl.querySelector<HTMLButtonElement>("#play-end-button");
+		if (endButton) {
+			endButton.addEventListener("click", () => {
+				const holdPlaceId = endButton.dataset.holdPlaceId;
+				if (!holdPlaceId) return;
+				void this.handleEndHoldPlacePlay(holdPlaceId);
 			});
 		}
 	}

--- a/src/api/places.ts
+++ b/src/api/places.ts
@@ -15,11 +15,9 @@ export interface StartPlacePlayResult {
 	holdPlaceId: string;
 	placeId: string;
 	playId: string;
-	gameCode: string;
 	gameTitle: string;
 	gameDescription: string;
 	contentUrl: string;
-	inputAdapter: string;
 	expireAt?: string;
 	joinPath: string;
 }
@@ -30,11 +28,9 @@ export interface LaunchHoldPlacePlayResult {
 	playId: string;
 	mode: "active" | "passive";
 	userId: string;
-	gameCode: string;
 	gameTitle: string;
 	gameDescription: string;
 	contentUrl: string;
-	inputAdapter: string;
 	expireAt?: string;
 	playToken: string;
 	playlogServerUrl: string;

--- a/src/api/places.ts
+++ b/src/api/places.ts
@@ -7,3 +7,48 @@ export async function holdPlace(client: Client, placeId: string) {
 export async function releasePlace(client: Client, placeId: string) {
 	return client.callWithAuthorization<{ result: string }>("POST", `/places/${placeId}/release`);
 }
+
+export interface StartPlacePlayResult {
+	holdPlaceId: string;
+	placeId: string;
+	playId: string;
+	gameCode: string;
+	gameTitle: string;
+	gameDescription: string;
+	contentUrl: string;
+	inputAdapter: string;
+	expireAt?: string;
+	joinPath: string;
+}
+
+export interface LaunchHoldPlacePlayResult {
+	holdPlaceId: string;
+	placeId: string;
+	playId: string;
+	mode: "active" | "passive";
+	userId: string;
+	gameCode: string;
+	gameTitle: string;
+	gameDescription: string;
+	contentUrl: string;
+	inputAdapter: string;
+	expireAt?: string;
+	playToken: string;
+	playlogServerUrl: string;
+	gamePageUrl: string;
+}
+
+export async function startPlacePlay(client: Client, placeId: string) {
+	return client.callWithAuthorization<StartPlacePlayResult>("POST", `/places/${placeId}/play/start`);
+}
+
+export async function launchHoldPlacePlay(client: Client, holdPlaceId: string) {
+	return client.callWithAuthorization<LaunchHoldPlacePlayResult>("POST", `/holdPlaces/${holdPlaceId}/play/launch`);
+}
+
+export async function endHoldPlacePlay(client: Client, holdPlaceId: string) {
+	return client.callWithAuthorization<{ result: string; holdPlaceId: string; placeId?: string; playId?: string }>(
+		"POST",
+		`/holdPlaces/${holdPlaceId}/play/end`,
+	);
+}

--- a/src/api/places.ts
+++ b/src/api/places.ts
@@ -1,11 +1,14 @@
 import type { Client } from "./client";
 
 export async function holdPlace(client: Client, placeId: string) {
-	return client.callWithAuthorization<{ holdPlaceId: string }>("POST", `/places/${placeId}/hold`);
+	return client.callWithAuthorization<{ holdPlaceId: string }>(
+		"POST",
+		`/places/${encodeURIComponent(placeId)}/hold`,
+	);
 }
 
 export async function releasePlace(client: Client, placeId: string) {
-	return client.callWithAuthorization<{ result: string }>("POST", `/places/${placeId}/release`);
+	return client.callWithAuthorization<{ result: string }>("POST", `/places/${encodeURIComponent(placeId)}/release`);
 }
 
 export interface StartPlacePlayResult {
@@ -39,16 +42,22 @@ export interface LaunchHoldPlacePlayResult {
 }
 
 export async function startPlacePlay(client: Client, placeId: string) {
-	return client.callWithAuthorization<StartPlacePlayResult>("POST", `/places/${placeId}/play/start`);
+	return client.callWithAuthorization<StartPlacePlayResult>(
+		"POST",
+		`/places/${encodeURIComponent(placeId)}/play/start`,
+	);
 }
 
 export async function launchHoldPlacePlay(client: Client, holdPlaceId: string) {
-	return client.callWithAuthorization<LaunchHoldPlacePlayResult>("POST", `/holdPlaces/${holdPlaceId}/play/launch`);
+	return client.callWithAuthorization<LaunchHoldPlacePlayResult>(
+		"POST",
+		`/holdPlaces/${encodeURIComponent(holdPlaceId)}/play/launch`,
+	);
 }
 
 export async function endHoldPlacePlay(client: Client, holdPlaceId: string) {
 	return client.callWithAuthorization<{ result: string; holdPlaceId: string; placeId?: string; playId?: string }>(
 		"POST",
-		`/holdPlaces/${holdPlaceId}/play/end`,
+		`/holdPlaces/${encodeURIComponent(holdPlaceId)}/play/end`,
 	);
 }

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -24,6 +24,14 @@ function normalizeHoldPlace(id: string, data: Partial<HoldPlace> | undefined): H
 		behaviours: Array.isArray(data?.behaviours) ? (data.behaviours as PlaceBehaviour[]) : [],
 		holdUserId: typeof data?.holdUserId === "string" ? data.holdUserId : undefined,
 		currentPlayId: typeof data?.currentPlayId === "string" ? data.currentPlayId : undefined,
+		currentPlayGameCode: typeof data?.currentPlayGameCode === "string" ? data.currentPlayGameCode : undefined,
+		currentPlayTitle: typeof data?.currentPlayTitle === "string" ? data.currentPlayTitle : undefined,
+		currentPlayDescription:
+			typeof data?.currentPlayDescription === "string" ? data.currentPlayDescription : undefined,
+		currentPlayContentUrl: typeof data?.currentPlayContentUrl === "string" ? data.currentPlayContentUrl : undefined,
+		currentPlayInputAdapter:
+			typeof data?.currentPlayInputAdapter === "string" ? data.currentPlayInputAdapter : undefined,
+		activeUserId: typeof data?.activeUserId === "string" ? data.activeUserId : undefined,
 		expireAt: data?.expireAt,
 		endedAt: data?.endedAt,
 	};

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -24,14 +24,6 @@ function normalizeHoldPlace(id: string, data: Partial<HoldPlace> | undefined): H
 		behaviours: Array.isArray(data?.behaviours) ? (data.behaviours as PlaceBehaviour[]) : [],
 		holdUserId: typeof data?.holdUserId === "string" ? data.holdUserId : undefined,
 		currentPlayId: typeof data?.currentPlayId === "string" ? data.currentPlayId : undefined,
-		currentPlayGameCode: typeof data?.currentPlayGameCode === "string" ? data.currentPlayGameCode : undefined,
-		currentPlayTitle: typeof data?.currentPlayTitle === "string" ? data.currentPlayTitle : undefined,
-		currentPlayDescription:
-			typeof data?.currentPlayDescription === "string" ? data.currentPlayDescription : undefined,
-		currentPlayContentUrl: typeof data?.currentPlayContentUrl === "string" ? data.currentPlayContentUrl : undefined,
-		currentPlayInputAdapter:
-			typeof data?.currentPlayInputAdapter === "string" ? data.currentPlayInputAdapter : undefined,
-		activeUserId: typeof data?.activeUserId === "string" ? data.activeUserId : undefined,
 		expireAt: data?.expireAt,
 		endedAt: data?.endedAt,
 	};

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -13,7 +13,7 @@ function normalizePlace(id: string, data: Partial<Place> | undefined): Place {
 		y: typeof data?.y === "number" ? data.y : 0,
 		name: data?.name ?? id,
 		behaviours: Array.isArray(data?.behaviours) ? (data.behaviours as PlaceBehaviour[]) : [],
-		currentHoldPlaceId: typeof data?.currentHoldPlaceId === "string" ? data.currentHoldPlaceId : undefined,
+		currentHoldPlaceId: data?.currentHoldPlaceId,
 	};
 }
 
@@ -22,8 +22,8 @@ function normalizeHoldPlace(id: string, data: Partial<HoldPlace> | undefined): H
 		id,
 		placeId: data?.placeId ?? "",
 		behaviours: Array.isArray(data?.behaviours) ? (data.behaviours as PlaceBehaviour[]) : [],
-		holdUserId: typeof data?.holdUserId === "string" ? data.holdUserId : undefined,
-		currentPlayId: typeof data?.currentPlayId === "string" ? data.currentPlayId : undefined,
+		holdUserId: data?.holdUserId,
+		currentPlayId: data?.currentPlayId,
 		expireAt: data?.expireAt,
 		endedAt: data?.endedAt,
 	};

--- a/src/types/holdPlace.ts
+++ b/src/types/holdPlace.ts
@@ -7,12 +7,6 @@ export interface HoldPlace {
 	behaviours: PlaceBehaviour[];
 	holdUserId?: string;
 	currentPlayId?: string;
-	currentPlayGameCode?: string;
-	currentPlayTitle?: string;
-	currentPlayDescription?: string;
-	currentPlayContentUrl?: string;
-	currentPlayInputAdapter?: string;
-	activeUserId?: string;
 	expireAt?: Timestamp;
 	endedAt?: Timestamp;
 }

--- a/src/types/holdPlace.ts
+++ b/src/types/holdPlace.ts
@@ -7,6 +7,12 @@ export interface HoldPlace {
 	behaviours: PlaceBehaviour[];
 	holdUserId?: string;
 	currentPlayId?: string;
+	currentPlayGameCode?: string;
+	currentPlayTitle?: string;
+	currentPlayDescription?: string;
+	currentPlayContentUrl?: string;
+	currentPlayInputAdapter?: string;
+	activeUserId?: string;
 	expireAt?: Timestamp;
 	endedAt?: Timestamp;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,8 @@ export type Route =
 	| { name: "my" }
 	| { name: "my-edit" }
 	| { name: "top" }
-	| { name: "place"; placeId: string };
+	| { name: "place"; placeId: string }
+	| { name: "play"; holdPlaceId: string };
 
 export function parseRoute(): Route {
 	const path = window.location.pathname || "/";
@@ -36,6 +37,12 @@ export function parseRoute(): Route {
 		const placeId = decodeURIComponent(path.replace("/place/", ""));
 		if (placeId) {
 			return { name: "place", placeId };
+		}
+	}
+	if (path.startsWith("/play/")) {
+		const holdPlaceId = decodeURIComponent(path.replace("/play/", ""));
+		if (holdPlaceId) {
+			return { name: "play", holdPlaceId };
 		}
 	}
 	if (path.startsWith("/my/edit")) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,9 @@ export type Route =
 
 function decodeRouteComponent(value: string) {
 	try {
-		return decodeURIComponent(value);
+		const decoded = decodeURIComponent(value);
+		if (!decoded || decoded.includes("/")) return undefined;
+		return decoded;
 	} catch {
 		return undefined;
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,16 +31,24 @@ export type Route =
 	| { name: "place"; placeId: string }
 	| { name: "play"; holdPlaceId: string };
 
+function decodeRouteComponent(value: string) {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return undefined;
+	}
+}
+
 export function parseRoute(): Route {
 	const path = window.location.pathname || "/";
 	if (path.startsWith("/place/")) {
-		const placeId = decodeURIComponent(path.replace("/place/", ""));
+		const placeId = decodeRouteComponent(path.replace("/place/", ""));
 		if (placeId) {
 			return { name: "place", placeId };
 		}
 	}
 	if (path.startsWith("/play/")) {
-		const holdPlaceId = decodeURIComponent(path.replace("/play/", ""));
+		const holdPlaceId = decodeRouteComponent(path.replace("/play/", ""));
 		if (holdPlaceId) {
 			return { name: "play", holdPlaceId };
 		}


### PR DESCRIPTION
## Summary
- Add Scramble functions endpoints to create, launch, and end Akashic System plays for held places
- Resolve Game Drive content.json from a configured contentId and store play metadata on the hold place
- Add a /play/:holdPlaceId page that passes play token and Playlog Server URL to Akashic System by postMessage
- Keep placeholder game description empty

## Verification
- npm run build
- npm --prefix functions run build

## Notes
- This PR does not include Akashic System server changes. The Akashic System postMessage support is tracked in shinonomekazan/akashic-system-multiplayer-server.
- Browser testing from a phone requires a reachable Scramble URL; localhost only supports same-PC browser testing.