### PR TITLE
PlaceからPlayへ自動遷移する

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -932,9 +932,6 @@ export class App {
 							${expireText ? `<div class="small text-muted mb-2">このPlayは ${utils.escapeHtml(expireText)} まで遊べます。</div>` : ""}
 							<div class="small text-break mb-2">${utils.escapeHtml(joinUrl)}</div>
 							<div class="d-flex flex-wrap gap-2">
-								<button id="place-open-play-button" class="btn btn-primary btn-sm" data-url="${utils.escapeHtml(
-									joinUrl,
-								)}" type="button">ゲームを開く</button>
 								<button id="place-copy-play-button" class="btn btn-outline-secondary btn-sm" data-url="${utils.escapeHtml(
 									joinUrl,
 								)}" type="button">URLをコピー</button>
@@ -953,7 +950,6 @@ export class App {
 				} else if (isSelfHolding) {
 					playMarkup = `
 						<div class="mt-3 p-3 border rounded-3 bg-light">
-							<div class="small text-muted mb-1">選択中のゲーム</div>
 							<div class="fw-semibold mb-1">${utils.escapeHtml(fixedGameTitle)}</div>
 							${fixedGameDescriptionMarkup}
 							<button id="place-start-play-button" class="btn btn-primary btn-sm" data-place-id="${utils.escapeHtml(
@@ -1247,6 +1243,11 @@ export class App {
 						return;
 					}
 
+					if (holdPlace.currentPlayId) {
+						this.navigateToPlay(watchHoldId);
+						return;
+					}
+
 					const baseSelectedPlace =
 						this.placeState.selectedPlace?.id === watchPlaceId
 							? this.placeState.selectedPlace
@@ -1435,7 +1436,7 @@ export class App {
 			this.showToast("ゲームを開始しました。", "success");
 			const joinPath = response.data.joinPath;
 			if (joinPath) {
-				utils.navigateTo(joinPath);
+				this.navigateToPlay(holdPlaceId);
 			}
 		} catch (err) {
 			const message = err instanceof Error ? err.message : "ゲーム開始に失敗しました。";
@@ -1450,6 +1451,12 @@ export class App {
 				this.render();
 			}
 		}
+	}
+
+	navigateToPlay(holdPlaceId: string) {
+		const route = utils.parseRoute();
+		if (route.name === "play" && route.holdPlaceId === holdPlaceId) return;
+		utils.navigateTo(`/play/${encodeURIComponent(holdPlaceId)}`);
 	}
 
 	async handleEndHoldPlacePlay(holdPlaceId: string) {
@@ -1659,15 +1666,6 @@ export class App {
 				const placeId = startPlayButton.dataset.placeId;
 				if (!placeId) return;
 				void this.handleStartPlacePlay(placeId);
-			});
-		}
-
-		const openPlayButton = this.rootEl.querySelector<HTMLButtonElement>("#place-open-play-button");
-		if (openPlayButton) {
-			openPlayButton.addEventListener("click", () => {
-				const url = openPlayButton.dataset.url;
-				if (!url) return;
-				location.href = url;
 			});
 		}
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -1245,7 +1245,7 @@ export class App {
 						return;
 					}
 
-					// A restarted listener can briefly report stale cache data, so retain this ID until another Play starts.
+					// 監視の再開直後はキャッシュの古い値が返ることがあるため、別のPlayが始まるまで終了済みPlayのIDを保持する。
 					const isLastEndedPlay = holdPlace.currentPlayId === this.lastEndedPlayId;
 					if (holdPlace.currentPlayId && !isLastEndedPlay) {
 						this.lastEndedPlayId = null;
@@ -1443,7 +1443,7 @@ export class App {
 			this.showToast("ゲームを開始しました。", "success");
 			const joinPath = response.data.joinPath;
 			if (joinPath) {
-				this.navigateToPlay(holdPlaceId);
+				this.navigateToPlay(holdPlaceId, joinPath);
 			}
 		} catch (err) {
 			const message = err instanceof Error ? err.message : "ゲーム開始に失敗しました。";
@@ -1460,10 +1460,13 @@ export class App {
 		}
 	}
 
-	navigateToPlay(holdPlaceId: string) {
+	navigateToPlay(
+		holdPlaceId: string,
+		joinPath = `/play/${encodeURIComponent(holdPlaceId)}`,
+	) {
 		const route = utils.parseRoute();
 		if (route.name === "play" && route.holdPlaceId === holdPlaceId) return;
-		utils.navigateTo(`/play/${encodeURIComponent(holdPlaceId)}`);
+		utils.navigateTo(joinPath);
 	}
 
 	async handleEndHoldPlacePlay(holdPlaceId: string) {

--- a/src/App.ts
+++ b/src/App.ts
@@ -95,7 +95,7 @@ export class App {
 	placeWatchId: string | null;
 	holdPlaceWatchUnsub: (() => void) | null;
 	holdPlaceWatchId: string | null;
-	endedPlayIdPendingSync: string | null;
+	lastEndedPlayId: string | null;
 	topPointerState: TopPointerState;
 
 	constructor(config: AppConfig = appConfig as AppConfig) {
@@ -168,7 +168,7 @@ export class App {
 		this.placeWatchId = null;
 		this.holdPlaceWatchUnsub = null;
 		this.holdPlaceWatchId = null;
-		this.endedPlayIdPendingSync = null;
+		this.lastEndedPlayId = null;
 		this.topPointerState = {
 			pointerId: null,
 			startClientX: 0,
@@ -1245,15 +1245,12 @@ export class App {
 						return;
 					}
 
-					const isEndedPlayPendingSync =
-						holdPlace.currentPlayId === this.endedPlayIdPendingSync;
-					if (holdPlace.currentPlayId && !isEndedPlayPendingSync) {
-						this.endedPlayIdPendingSync = null;
+					// A restarted listener can briefly report stale cache data, so retain this ID until another Play starts.
+					const isLastEndedPlay = holdPlace.currentPlayId === this.lastEndedPlayId;
+					if (holdPlace.currentPlayId && !isLastEndedPlay) {
+						this.lastEndedPlayId = null;
 						this.navigateToPlay(watchHoldId);
 						return;
-					}
-					if (!holdPlace.currentPlayId) {
-						this.endedPlayIdPendingSync = null;
 					}
 
 					const baseSelectedPlace =
@@ -1265,7 +1262,7 @@ export class App {
 						selectedPlace: baseSelectedPlace
 							? { ...baseSelectedPlace, currentHoldPlaceId: watchHoldId }
 							: null,
-						selectedHoldPlace: isEndedPlayPendingSync
+						selectedHoldPlace: isLastEndedPlay
 							? { ...holdPlace, currentPlayId: undefined }
 							: holdPlace,
 						selectedHoldPlaceLoading: false,
@@ -1484,7 +1481,7 @@ export class App {
 		try {
 			const response = await endHoldPlacePlay(this.client, holdPlaceId);
 			this.showToast("Playを終了しました。", "success");
-			this.endedPlayIdPendingSync =
+			this.lastEndedPlayId =
 				response.data.playId ??
 				this.playLaunchState.launch?.playId ??
 				this.placeState.selectedHoldPlace?.currentPlayId ??

--- a/src/App.ts
+++ b/src/App.ts
@@ -95,6 +95,7 @@ export class App {
 	placeWatchId: string | null;
 	holdPlaceWatchUnsub: (() => void) | null;
 	holdPlaceWatchId: string | null;
+	endedPlayIdPendingSync: string | null;
 	topPointerState: TopPointerState;
 
 	constructor(config: AppConfig = appConfig as AppConfig) {
@@ -167,6 +168,7 @@ export class App {
 		this.placeWatchId = null;
 		this.holdPlaceWatchUnsub = null;
 		this.holdPlaceWatchId = null;
+		this.endedPlayIdPendingSync = null;
 		this.topPointerState = {
 			pointerId: null,
 			startClientX: 0,
@@ -1243,9 +1245,15 @@ export class App {
 						return;
 					}
 
-					if (holdPlace.currentPlayId) {
+					const isEndedPlayPendingSync =
+						holdPlace.currentPlayId === this.endedPlayIdPendingSync;
+					if (holdPlace.currentPlayId && !isEndedPlayPendingSync) {
+						this.endedPlayIdPendingSync = null;
 						this.navigateToPlay(watchHoldId);
 						return;
+					}
+					if (!holdPlace.currentPlayId) {
+						this.endedPlayIdPendingSync = null;
 					}
 
 					const baseSelectedPlace =
@@ -1257,7 +1265,9 @@ export class App {
 						selectedPlace: baseSelectedPlace
 							? { ...baseSelectedPlace, currentHoldPlaceId: watchHoldId }
 							: null,
-						selectedHoldPlace: holdPlace,
+						selectedHoldPlace: isEndedPlayPendingSync
+							? { ...holdPlace, currentPlayId: undefined }
+							: holdPlace,
 						selectedHoldPlaceLoading: false,
 						selectedHoldPlaceError: null,
 					};
@@ -1474,6 +1484,11 @@ export class App {
 		try {
 			const response = await endHoldPlacePlay(this.client, holdPlaceId);
 			this.showToast("Playを終了しました。", "success");
+			this.endedPlayIdPendingSync =
+				response.data.playId ??
+				this.playLaunchState.launch?.playId ??
+				this.placeState.selectedHoldPlace?.currentPlayId ??
+				null;
 			if (this.playLaunchState.holdPlaceId === holdPlaceId) {
 				this.playLaunchState = {
 					...this.playLaunchState,


### PR DESCRIPTION
## 変更内容
- Play開始を検知したPlace画面からPlay画面へ自動遷移
- Play中のPlaceへアクセスした場合もPlay画面へ自動遷移
- 「ゲームを開く」ボタンを削除
- 「選択中のゲーム」表示を削除

## 確認
- webpack build 成功
- git diff --check 成功
- Firebase Hosting Previewで複数アカウントによる以下の動作を確認
  - Placeを確保したユーザーがPlayを開始するとPlay画面へ遷移する
  - 同じPlaceで待機中の別ユーザーもPlay画面へ自動遷移する
  - Play中のPlaceへ直接アクセスするとPlay画面へ自動遷移する
  - 「ゲームを開く」「選択中のゲーム」が表示されない

## マージ時の影響
- src配下の変更のため、mainへのマージ後はFirebase Hostingが自動デプロイされます
- Functionsの変更・デプロイはありません

## 本PRの対象外
- Active側のリロード・再アクセス時の復帰
- Play画面遷移後のマルチプレイ入力